### PR TITLE
fix: tool命名兼容augment

### DIFF
--- a/src/tools/get-version.ts
+++ b/src/tools/get-version.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import packageJson from "../../package.json";
 
-const VERSION_TOOL_NAME = `version_${packageJson.version}`;
+const VERSION_TOOL_NAME = `version_${packageJson.version.replace(/\./g, '_')}`;
 const VERSION_TOOL_DESCRIPTION = `the current version is ${packageJson.version}`;
 
 export class GetVersionTool extends BaseTool {


### PR DESCRIPTION
你好，

mcp工具：
>     version_0.0.4-beta.11
会触发augment code的错误：
> Invalid tool definition Tool name does not match the required pattern ^[a-zA-Z0-9_-]{1,64}$

图片见下方

建议对工具名的"."进行替换，替换为"_"


望采纳

![image](https://github.com/user-attachments/assets/075e00c7-2c32-4f06-82f5-fe60d482d8be)
![image](https://github.com/user-attachments/assets/ecb375ef-c48a-4337-b5bf-f38379321618)
