### PR TITLE
docs: update README and README.zh-CN to reflect new entry point for l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,14 @@ Contains markdown files with additional documentation:
 ## Local Development
 
 1. Run `yarn` and `yarn build` to install dependencies and build the code
-2. Find the absolute path of `bin/cli.js`
+2. Find the absolute path of `dist/index.js`
 3. Add local MCP configuration with your token
 
 ```json
 "mastergo-mcp-local": {
   "command": "node",
   "args": [
-    "absolute/path/to/bin/cli.js",
+    "absolute/path/to/dist/index.js",
     "--token=mg_xxxxxx",
     "--url=https://mastergo.com",
     "--debug"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,14 +184,14 @@ Cursor Mcp 使用指南参考：https://docs.cursor.com/context/model-context-pr
 ## 本地开发
 
 1. 运行 `yarn` 和 `yarn build`，安装依赖并构建代码
-2. 查看 `bin/cli.js` 的绝对路径
+2. 查看 `dist/index.js` 的绝对路径
 3. 在 MCP 配置中添加本地 MCP 配置，其中 token 为您获取的 token
 
 ```json
 "mastergo-mcp-local": {
   "command": "node",
   "args": [
-    "bin/cli.js绝对路径地址",
+    "dist/index.js绝对路径地址",
     "--token=mg_xxxxxx",
     "--url=https://mastergo.com",
     "--debug"


### PR DESCRIPTION
…ocal development

- Changed references from `bin/cli.js` to `dist/index.js` in both English and Chinese documentation.
- Ensured instructions for local development are consistent with the updated file structure.