### PR TITLE
feat: support per-call token via tools/call _meta.userToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ Alternatively, you can use environment variables instead of command line argumen
 - `API_BASE_URL`: API base URL
 - `RULES`: JSON array of rules (e.g., `'["rule1", "rule2"]'`)
 
+### Per-call token (`tools/call` `_meta.userToken`)
+
+Hosted / multi-tenant MCP hosts can pass a different MasterGo token per tool invocation without spawning extra processes. When present, it overrides startup `--token` / env for **that request only** (via `AsyncLocalStorage`). Empty strings are ignored.
+
+MCP client example (pseudo JSON-RPC `tools/call` params):
+
+```json
+{
+  "name": "mcp__getDsl",
+  "arguments": { "fileId": "123", "layerId": "456:789" },
+  "_meta": { "userToken": "mg_your_runtime_token" }
+}
+```
+
+If `_meta.userToken` is omitted, behavior matches upstream (argv → `MG_MCP_TOKEN` → `MASTERGO_API_TOKEN`).
+
 ### Installing via Smithery Marketplace
 
 Smithery is an MCP server marketplace that makes it easy to install and manage MCP services.

--- a/build.js
+++ b/build.js
@@ -1,138 +1,132 @@
 #!/usr/bin/env node
 
-const esbuild = require("esbuild");
-const { execSync } = require("child_process");
-const fs = require("fs");
-const path = require("path");
+const esbuild = require('esbuild');
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 // Ensure the dist directory exists
-if (!fs.existsSync("dist")) {
-  fs.mkdirSync("dist");
+if (!fs.existsSync('dist')) {
+    fs.mkdirSync('dist');
 }
 
 // Recursively delete a directory
 function removeDir(dirPath) {
-  if (fs.existsSync(dirPath)) {
-    fs.readdirSync(dirPath).forEach((file) => {
-      const curPath = path.join(dirPath, file);
-      if (fs.lstatSync(curPath).isDirectory()) {
-        // Recursively delete subdirectories
-        removeDir(curPath);
-      } else {
-        // Delete the file
-        fs.unlinkSync(curPath);
-      }
-    });
-    // Delete the directory itself
-    fs.rmdirSync(dirPath);
-  }
+    if (fs.existsSync(dirPath)) {
+        fs.readdirSync(dirPath).forEach((file) => {
+            const curPath = path.join(dirPath, file);
+            if (fs.lstatSync(curPath).isDirectory()) {
+                // Recursively delete subdirectories
+                removeDir(curPath);
+            } else {
+                // Delete the file
+                fs.unlinkSync(curPath);
+            }
+        });
+        // Delete the directory itself
+        fs.rmdirSync(dirPath);
+    }
 }
 
 async function build() {
-  try {
-    console.log("🚀 Starting the build process...");
+    try {
+        console.log('🚀 Starting the build process...');
 
-    // Clean up old build files
-    console.log("🧹 Cleaning up old build files...");
-    if (fs.existsSync("dist")) {
-      // First delete the dist directory
-      removeDir("dist");
-      // Re-create the dist directory
-      fs.mkdirSync("dist");
+        // Clean up old build files
+        console.log('🧹 Cleaning up old build files...');
+        if (fs.existsSync('dist')) {
+            // First delete the dist directory
+            removeDir('dist');
+            // Re-create the dist directory
+            fs.mkdirSync('dist');
+        }
+
+        // Use esbuild to bundle all code into a single file
+        console.log('📦 Using esbuild to bundle all code into a single file...');
+        await esbuild.build({
+            entryPoints: ['src/index.ts'],
+            bundle: true,
+            platform: 'node',
+            target: 'node16',
+            outfile: 'dist/index.js',
+            minify: true,
+            sourcemap: false,
+            format: 'cjs',
+            // Exclude only node built-in modules to ensure all third-party dependencies are bundled
+            external: [
+                'path',
+                'fs',
+                'child_process',
+                'http',
+                'https',
+                'util',
+                'os',
+                'stream',
+                'zlib',
+                'events',
+                'buffer',
+                'crypto',
+                'net',
+                'dns',
+                'tls',
+                'url',
+                'querystring',
+                'assert'
+            ],
+            // Ensure all modules are correctly resolved
+            resolveExtensions: ['.ts', '.js', '.json', '.node'],
+            // Ensure all dependencies are correctly loaded
+            loader: {
+                '.ts': 'ts',
+                '.js': 'js',
+                '.json': 'json',
+                '.node': 'file',
+                '.md': 'text'
+            },
+            // Define environment variables
+            define: {
+                'process.env.NODE_ENV': '"production"'
+            },
+            // Enable tree shaking
+            treeShaking: true
+        });
+
+        // Verify if only one file is generated
+        console.log('🔍 Verifying the build output...');
+        const files = fs.readdirSync('dist');
+        if (files.length > 1 || (files.length === 1 && files[0] !== 'index.js')) {
+            console.warn('⚠️ Warning: The build produced multiple files, not a single file');
+            console.warn('📁 File list:', files);
+        } else {
+            console.log('✅ Verification successful: All code has been bundled into a single file');
+        }
+
+        // The file header is already in the source file, no need to add it again
+        console.log('✅ The source file already includes the shebang, no need to add it again');
+
+        // Add executable permissions
+        console.log('🔑 Adding executable permissions...');
+        fs.chmodSync('dist/index.js', '755');
+
+        // Display file size
+        const stats = fs.statSync('dist/index.js');
+        const fileSizeInKB = (stats.size / 1024).toFixed(2);
+        console.log(`📦 Build output size: ${fileSizeInKB} KB`);
+
+        console.log('✅ Build successful！');
+        console.log('📦 Executable file located at: dist/index.js');
+
+        console.log('🚀 You can publish the package using the following command:');
+        console.log('   npm publish');
+        console.log('');
+        console.log('🔧 Or you can test locally using the following command:');
+        console.log(
+            '   node dist/index.js --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--no-rule] [--debug]'
+        );
+    } catch (error) {
+        console.error('❌ Build failed:', error);
+        process.exit(1);
     }
-
-    // Use esbuild to bundle all code into a single file
-    console.log("📦 Using esbuild to bundle all code into a single file...");
-    await esbuild.build({
-      entryPoints: ["src/index.ts"],
-      bundle: true,
-      platform: "node",
-      target: "node16",
-      outfile: "dist/index.js",
-      minify: true,
-      sourcemap: false,
-      format: "cjs",
-      // Exclude only node built-in modules to ensure all third-party dependencies are bundled
-      external: [
-        "path",
-        "fs",
-        "child_process",
-        "http",
-        "https",
-        "util",
-        "os",
-        "stream",
-        "zlib",
-        "events",
-        "buffer",
-        "crypto",
-        "net",
-        "dns",
-        "tls",
-        "url",
-        "querystring",
-        "assert",
-      ],
-      // Ensure all modules are correctly resolved
-      resolveExtensions: [".ts", ".js", ".json", ".node"],
-      // Ensure all dependencies are correctly loaded
-      loader: {
-        ".ts": "ts",
-        ".js": "js",
-        ".json": "json",
-        ".node": "file",
-        ".md": "text",
-      },
-      // Define environment variables
-      define: {
-        "process.env.NODE_ENV": '"production"',
-      },
-      // Enable tree shaking
-      treeShaking: true,
-    });
-
-    // Verify if only one file is generated
-    console.log("🔍 Verifying the build output...");
-    const files = fs.readdirSync("dist");
-    if (files.length > 1 || (files.length === 1 && files[0] !== "index.js")) {
-      console.warn(
-        "⚠️ Warning: The build produced multiple files, not a single file"
-      );
-      console.warn("📁 File list:", files);
-    } else {
-      console.log(
-        "✅ Verification successful: All code has been bundled into a single file"
-      );
-    }
-
-    // The file header is already in the source file, no need to add it again
-    console.log(
-      "✅ The source file already includes the shebang, no need to add it again"
-    );
-
-    // Add executable permissions
-    console.log("🔑 Adding executable permissions...");
-    fs.chmodSync("dist/index.js", "755");
-
-    // Display file size
-    const stats = fs.statSync("dist/index.js");
-    const fileSizeInKB = (stats.size / 1024).toFixed(2);
-    console.log(`📦 Build output size: ${fileSizeInKB} KB`);
-
-    console.log("✅ Build successful！");
-    console.log("📦 Executable file located at: dist/index.js");
-
-    console.log("🚀 You can publish the package using the following command:");
-    console.log("   npm publish");
-    console.log("");
-    console.log("🔧 Or you can test locally using the following command:");
-    console.log(
-      "   node dist/index.js --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--no-rule] [--debug]"
-    );
-  } catch (error) {
-    console.error("❌ Build failed:", error);
-    process.exit(1);
-  }
 }
 
 build();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastergo/magic-mcp",
-  "version": "0.1.7-beta.0",
+  "version": "0.1.8-beta.0",
   "description": "MasterGo MCP standalone service",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,48 +1,49 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { GetDslTool } from "./tools/get-dsl";
-import { GetD2cTool } from "./tools/get-d2c";
-import { GetC2dTool } from "./tools/get-c2d";
-import { GetComponentLinkTool } from "./tools/get-component-link";
-import { GetMetaTool } from "./tools/get-meta";
-import { GetComponentWorkflowTool } from "./tools/get-component-workflow";
-import { GetVersionTool } from "./tools/get-version";
-import { parserArgs } from "./utils/args";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { GetC2dTool } from './tools/get-c2d';
+import { GetComponentLinkTool } from './tools/get-component-link';
+import { GetComponentWorkflowTool } from './tools/get-component-workflow';
+import { GetD2cTool } from './tools/get-d2c';
+import { GetDslTool } from './tools/get-dsl';
+import { GetMetaTool } from './tools/get-meta';
+import { GetVersionTool } from './tools/get-version';
+import { parserArgs } from './utils/args';
 
 // Main function
 function main() {
-  // Parse command line arguments and set environment variables
-  const { token, baseUrl, rules, debug, noRule } = parserArgs();
+    // Parse command line arguments and set environment variables
+    const { token, baseUrl, rules, debug, noRule } = parserArgs();
 
-  if (debug) {
-    process.env.DEBUG = "true";
-    console.log("Debug information:");
-    console.log(`Token: ${token ? "set" : "not set"}`);
-    console.log(`API URL: ${baseUrl || "default"}`);
-    console.log(`Rules: ${rules.length > 0 ? rules.join(", ") : "none"}`);
-    console.log(`No Rule: ${noRule ? "enabled" : "disabled"}`);
-    console.log(`Debug mode: enabled`);
-  }
+    if (debug) {
+        process.env.DEBUG = 'true';
+        console.log('Debug information:');
+        console.log(`Startup token (argv/env): ${token ? 'set' : 'not set'}`);
+        console.log('Per-call tokens via tools/call _meta.userToken are never printed here (redacted by design).');
+        console.log(`API URL: ${baseUrl || 'default'}`);
+        console.log(`Rules: ${rules.length > 0 ? rules.join(', ') : 'none'}`);
+        console.log(`No Rule: ${noRule ? 'enabled' : 'disabled'}`);
+        console.log('Debug mode: enabled');
+    }
 
-  // Create server instance
-  const server = new McpServer({
-    name: "MasterGoMcpServer",
-    version: "0.0.1",
-  });
+    // Create server instance
+    const server = new McpServer({
+        name: 'MasterGoMcpServer',
+        version: '0.0.1'
+    });
 
-  // Register tools
-  new GetVersionTool().register(server);
-  new GetDslTool().register(server);
-  new GetD2cTool().register(server);
-  new GetC2dTool().register(server);
-  new GetComponentLinkTool().register(server);
-  new GetMetaTool().register(server);
-  new GetComponentWorkflowTool().register(server);
+    // Register tools
+    new GetVersionTool().register(server);
+    new GetDslTool().register(server);
+    new GetD2cTool().register(server);
+    new GetC2dTool().register(server);
+    new GetComponentLinkTool().register(server);
+    new GetMetaTool().register(server);
+    new GetComponentWorkflowTool().register(server);
 
-  // Connect to standard input/output
-  server.connect(new StdioServerTransport());
+    // Connect to standard input/output
+    server.connect(new StdioServerTransport());
 }
 
 // Start the program

--- a/src/tools/base-tool.ts
+++ b/src/tools/base-tool.ts
@@ -1,21 +1,31 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { z } from 'zod';
+import { requestTokenStore } from '../utils/request-context';
+
+type ToolExtra = { _meta?: Record<string, unknown> };
+
+function readUserTokenFromMeta(extra: ToolExtra | undefined): string | undefined {
+    const raw = extra?._meta?.userToken;
+    if (typeof raw !== 'string') {
+        return undefined;
+    }
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
 
 export abstract class BaseTool {
-  abstract name: string;
-  abstract description: string;
-  abstract schema: z.ZodObject<any>;
+    abstract name: string;
+    abstract description: string;
+    abstract schema: z.ZodObject<any>;
 
-  register(server: McpServer) {
-    server.tool(
-      this.name,
-      this.description,
-      this.schema.shape,
-      this.execute.bind(this)
-    );
-  }
+    register(server: McpServer) {
+        server.tool(this.name, this.description, this.schema.shape, async (args, extra) => {
+            const userToken = readUserTokenFromMeta(extra as ToolExtra);
+            return requestTokenStore.run(userToken, () => this.execute(args as z.infer<typeof this.schema>));
+        });
+    }
 
-  abstract execute(args: z.infer<typeof this.schema>): Promise<{
-    content: Array<{ type: "text"; text: string }>;
-  }>;
+    abstract execute(args: z.infer<typeof this.schema>): Promise<{
+        content: Array<{ type: 'text'; text: string }>;
+    }>;
 }

--- a/src/tools/get-c2d.ts
+++ b/src/tools/get-c2d.ts
@@ -1,9 +1,9 @@
-import { z } from "zod";
-import { BaseTool } from "./base-tool";
-import { httpUtilInstance } from "../utils/api";
-import fs from "fs";
+import fs from 'fs';
+import { z } from 'zod';
+import { httpUtilInstance } from '../utils/api';
+import { BaseTool } from './base-tool';
 
-const C2D_TOOL_NAME = "mcp__C2d";
+const C2D_TOOL_NAME = 'mcp__C2d';
 const C2D_TOOL_DESCRIPTION = `
 使用此工具将代码文件发送到 MasterGo MCP 服务进行 C2D（代码转设计）处理，将用户代码同步到设计稿。
 
@@ -19,103 +19,86 @@ const C2D_TOOL_DESCRIPTION = `
 `;
 
 export class GetC2dTool extends BaseTool {
-  name = C2D_TOOL_NAME;
-  description = C2D_TOOL_DESCRIPTION;
+    name = C2D_TOOL_NAME;
+    description = C2D_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
-
-  schema = z.object({
-    filePath: z
-      .string()
-      .min(1, "filePath 不能为空")
-      .describe("HTML 文件的完整路径，工具会读取文件内容并发送给后端"),
-    fileId: z
-      .string()
-      .optional()
-      .describe(
-        "文件 ID（URL 中 file= 或路径中的数字段）。未传 shortLink 时必填。"
-      ),
-    layerId: z
-      .string()
-      .optional()
-      .describe(
-        "可选。图层 ID（只读取 URL 参数 layer_id）。不传或解析不到则仅按 file 维度同步；pageid/page_id 不会被当作 layerId。"
-      ),
-    shortLink: z
-      .string()
-      .optional()
-      .describe("Short link (like https://{domain}/goto/LhGgBAK)."),
-  });
-
-  async execute({
-    filePath,
-    fileId,
-    layerId,
-    shortLink,
-  }: z.infer<typeof this.schema>) {
-    try {
-      const link = shortLink?.trim();
-      const fid = fileId?.trim();
-      const lid = layerId?.trim();
-
-      let finalFileId: string | undefined;
-      let finalLayerId: string | undefined;
-
-      if (link) {
-        const ids = await httpUtilInstance.extractIdsFromUrl(link);
-        finalFileId = this.normalizeFileId(ids.fileId);
-        finalLayerId = ids.layerId;
-      } else if (fid) {
-        finalFileId = this.normalizeFileId(fid);
-        finalLayerId = lid || undefined;
-      } else {
-        throw new Error("请传 shortLink，或至少传 fileId（layerId 可选）");
-      }
-
-      if (!finalFileId) {
-        throw new Error("Could not determine fileId");
-      }
-
-      // 读取文件内容作为 data 传给接口
-      let data: string;
-      try {
-        data = fs.readFileSync(filePath, "utf-8");
-      } catch (readError) {
-        throw new Error(`无法读取文件 ${filePath}: ${readError}`);
-      }
-
-      const result = await httpUtilInstance.postC2d(
-        data,
-        finalFileId,
-        finalLayerId
-      );
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(result),
-          },
-        ],
-      };
-    } catch (error: any) {
-      const errorMessage = error?.response?.data ?? error?.message;
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(errorMessage),
-          },
-        ],
-      };
+    constructor() {
+        super();
     }
-  }
 
-  private normalizeFileId(fileId?: string) {
-    if (!fileId) return fileId;
-    return fileId.replace(/^file\//, "");
-  }
+    schema = z.object({
+        filePath: z
+            .string()
+            .min(1, 'filePath 不能为空')
+            .describe('HTML 文件的完整路径，工具会读取文件内容并发送给后端'),
+        fileId: z.string().optional().describe('文件 ID（URL 中 file= 或路径中的数字段）。未传 shortLink 时必填。'),
+        layerId: z
+            .string()
+            .optional()
+            .describe(
+                '可选。图层 ID（只读取 URL 参数 layer_id）。不传或解析不到则仅按 file 维度同步；pageid/page_id 不会被当作 layerId。'
+            ),
+        shortLink: z.string().optional().describe('Short link (like https://{domain}/goto/LhGgBAK).')
+    });
+
+    async execute({ filePath, fileId, layerId, shortLink }: z.infer<typeof this.schema>) {
+        try {
+            const link = shortLink?.trim();
+            const fid = fileId?.trim();
+            const lid = layerId?.trim();
+
+            let finalFileId: string | undefined;
+            let finalLayerId: string | undefined;
+
+            if (link) {
+                const ids = await httpUtilInstance.extractIdsFromUrl(link);
+                finalFileId = this.normalizeFileId(ids.fileId);
+                finalLayerId = ids.layerId;
+            } else if (fid) {
+                finalFileId = this.normalizeFileId(fid);
+                finalLayerId = lid || undefined;
+            } else {
+                throw new Error('请传 shortLink，或至少传 fileId（layerId 可选）');
+            }
+
+            if (!finalFileId) {
+                throw new Error('Could not determine fileId');
+            }
+
+            // 读取文件内容作为 data 传给接口
+            let data: string;
+            try {
+                data = fs.readFileSync(filePath, 'utf-8');
+            } catch (readError) {
+                throw new Error(`无法读取文件 ${filePath}: ${readError}`);
+            }
+
+            const result = await httpUtilInstance.postC2d(data, finalFileId, finalLayerId);
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(result)
+                    }
+                ]
+            };
+        } catch (error: any) {
+            const errorMessage = error?.response?.data ?? error?.message;
+            return {
+                isError: true,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(errorMessage)
+                    }
+                ]
+            };
+        }
+    }
+
+    private normalizeFileId(fileId?: string) {
+        if (!fileId) return fileId;
+        return fileId.replace(/^file\//, '');
+    }
 }

--- a/src/tools/get-component-link.ts
+++ b/src/tools/get-component-link.ts
@@ -1,53 +1,54 @@
-import { z } from "zod";
-import { BaseTool } from "./base-tool";
-import { httpUtilInstance } from "../utils/api";
+import { z } from 'zod';
+import { httpUtilInstance } from '../utils/api';
+import { BaseTool } from './base-tool';
 
-const COMPONENT_LINK_TOOL_NAME = "mcp__getComponentLink";
-const COMPONENT_LINK_TOOL_DESCRIPTION = `When the data returned by mcp__getDsl contains a non-empty componentDocumentLinks array, this tool is used to sequentially retrieve URLs from the componentDocumentLinks array and then obtain component documentation data. The returned document data is used for you to generate frontend code based on components.`;
+const COMPONENT_LINK_TOOL_NAME = 'mcp__getComponentLink';
+const COMPONENT_LINK_TOOL_DESCRIPTION =
+    'When the data returned by mcp__getDsl contains a non-empty componentDocumentLinks array, this tool is used to sequentially retrieve URLs from the componentDocumentLinks array and then obtain component documentation data. The returned document data is used for you to generate frontend code based on components.';
 
 export class GetComponentLinkTool extends BaseTool {
-  name = COMPONENT_LINK_TOOL_NAME;
-  description = COMPONENT_LINK_TOOL_DESCRIPTION;
+    name = COMPONENT_LINK_TOOL_NAME;
+    description = COMPONENT_LINK_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
-
-  schema = z.object({
-    url: z
-      .string()
-      .describe(
-        "Component documentation link URL, from the componentDocumentLinks property, please ensure the URL is valid"
-      ),
-  });
-
-  async execute({ url }: z.infer<typeof this.schema>) {
-    try {
-      const data = await httpUtilInstance.request({
-        method: "GET",
-        url,
-      });
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `${data}`,
-          },
-        ],
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              error: "Failed to get component documentation",
-              message: error instanceof Error ? error.message : String(error),
-            }),
-          },
-        ],
-      };
+    constructor() {
+        super();
     }
-  }
+
+    schema = z.object({
+        url: z
+            .string()
+            .describe(
+                'Component documentation link URL, from the componentDocumentLinks property, please ensure the URL is valid'
+            )
+    });
+
+    async execute({ url }: z.infer<typeof this.schema>) {
+        try {
+            const data = await httpUtilInstance.request({
+                method: 'GET',
+                url
+            });
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: `${data}`
+                    }
+                ]
+            };
+        } catch (error) {
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify({
+                            error: 'Failed to get component documentation',
+                            message: error instanceof Error ? error.message : String(error)
+                        })
+                    }
+                ]
+            };
+        }
+    }
 }

--- a/src/tools/get-component-workflow.ts
+++ b/src/tools/get-component-workflow.ts
@@ -1,10 +1,10 @@
-import { z } from "zod";
-import fs from "fs";
-import { BaseTool } from "./base-tool";
-import { httpUtilInstance } from "../utils/api";
-import componentWorkflow from "../markdown/component-workflow.md";
+import fs from 'fs';
+import { z } from 'zod';
+import componentWorkflow from '../markdown/component-workflow.md';
+import { httpUtilInstance } from '../utils/api';
+import { BaseTool } from './base-tool';
 
-const COMPONENT_GENERATOR_TOOL_NAME = "mcp__getComponentGenerator";
+const COMPONENT_GENERATOR_TOOL_NAME = 'mcp__getComponentGenerator';
 const COMPONENT_GENERATOR_TOOL_DESCRIPTION = `
 Users need to actively call this tool to get the component development workflow. When Generator is mentioned, please actively call this tool.
 This tool provides a structured workflow for component development following best practices.
@@ -12,112 +12,108 @@ You must provide an absolute rootPath of workspace to save workflow files.
 `;
 
 export class GetComponentWorkflowTool extends BaseTool {
-  name = COMPONENT_GENERATOR_TOOL_NAME;
-  description = COMPONENT_GENERATOR_TOOL_DESCRIPTION;
+    name = COMPONENT_GENERATOR_TOOL_NAME;
+    description = COMPONENT_GENERATOR_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
-
-  schema = z.object({
-    rootPath: z
-      .string()
-      .describe(
-        "The root path of the project, if the user does not provide, you can use the current directory as the root path"
-      ),
-    fileId: z
-      .string()
-      .describe(
-        "MasterGo design file ID (format: file/<fileId> in MasterGo URL)"
-      ),
-    layerId: z
-      .string()
-      .describe(
-        "Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId> / file=<fileId> in MasterGo URL)"
-      ),
-    sourceLayerId: z
-      .string()
-      .optional()
-      .describe(
-        "Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries."
-      ),
-  });
-
-  async execute({ rootPath, fileId, layerId, sourceLayerId }: z.infer<typeof this.schema>) {
-    const baseDir = `${rootPath}/.mastergo/`;
-    if (!fs.existsSync(baseDir)) {
-      fs.mkdirSync(baseDir, { recursive: true });
+    constructor() {
+        super();
     }
-    const workflowFilePath = `${baseDir}/component-workflow.md`;
-    const jsonData = await httpUtilInstance.getComponentStyleJson(fileId, layerId, sourceLayerId);
-    const componentJsonDir = `${baseDir}/${jsonData[0].name}.json`;
-    const walkLayer = (layer: any) => {
-      if (layer.path && layer.path.length > 0) {
-        layer.imageUrls = [];
-        const id = layer.id.replaceAll("/", "&");
-        const imageDir = `${baseDir}/images`;
-        if (!fs.existsSync(imageDir)) {
-          fs.mkdirSync(imageDir, { recursive: true });
+
+    schema = z.object({
+        rootPath: z
+            .string()
+            .describe(
+                'The root path of the project, if the user does not provide, you can use the current directory as the root path'
+            ),
+        fileId: z.string().describe('MasterGo design file ID (format: file/<fileId> in MasterGo URL)'),
+        layerId: z
+            .string()
+            .describe(
+                'Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId> / file=<fileId> in MasterGo URL)'
+            ),
+        sourceLayerId: z
+            .string()
+            .optional()
+            .describe(
+                'Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries.'
+            )
+    });
+
+    async execute({ rootPath, fileId, layerId, sourceLayerId }: z.infer<typeof this.schema>) {
+        const baseDir = `${rootPath}/.mastergo/`;
+        if (!fs.existsSync(baseDir)) {
+            fs.mkdirSync(baseDir, { recursive: true });
         }
-        (layer.path ?? []).forEach((svgPath: string, index: number) => {
-          const filePath = `${imageDir}/${id}-${index}.svg`;
-          if (!fs.existsSync(filePath)) {
-            fs.writeFileSync(
-              filePath,
-              `<svg width="100%" height="100%" viewBox="0 0 16 16"xmlns="http://www.w3.org/2000/svg">
+        const workflowFilePath = `${baseDir}/component-workflow.md`;
+        const jsonData = await httpUtilInstance.getComponentStyleJson(fileId, layerId, sourceLayerId);
+        const componentJsonDir = `${baseDir}/${jsonData[0].name}.json`;
+        const walkLayer = (layer: any) => {
+            if (layer.path && layer.path.length > 0) {
+                layer.imageUrls = [];
+                const id = layer.id.replaceAll('/', '&');
+                const imageDir = `${baseDir}/images`;
+                if (!fs.existsSync(imageDir)) {
+                    fs.mkdirSync(imageDir, { recursive: true });
+                }
+                (layer.path ?? []).forEach((svgPath: string, index: number) => {
+                    const filePath = `${imageDir}/${id}-${index}.svg`;
+                    if (!fs.existsSync(filePath)) {
+                        fs.writeFileSync(
+                            filePath,
+                            `<svg width="100%" height="100%" viewBox="0 0 16 16"xmlns="http://www.w3.org/2000/svg">
   <path d="${svgPath}" fill="currentColor"/>
 </svg>`
-            );
-          }
-          layer.imageUrls.push(filePath);
-        });
-        delete layer.path;
-      }
-      if (layer.children) {
-        layer.children.forEach((child: any) => {
-          walkLayer(child);
-        });
-      }
-    };
-    walkLayer(jsonData[0]);
+                        );
+                    }
+                    layer.imageUrls.push(filePath);
+                });
+                delete layer.path;
+            }
+            if (layer.children) {
+                layer.children.forEach((child: any) => {
+                    walkLayer(child);
+                });
+            }
+        };
+        walkLayer(jsonData[0]);
 
-    //文件夹可能也不存在递归创建
-    if (!fs.existsSync(workflowFilePath)) {
-      fs.writeFileSync(workflowFilePath, componentWorkflow);
+        //文件夹可能也不存在递归创建
+        if (!fs.existsSync(workflowFilePath)) {
+            fs.writeFileSync(workflowFilePath, componentWorkflow);
+        }
+
+        fs.writeFileSync(componentJsonDir, JSON.stringify(jsonData[0]));
+
+        try {
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify({
+                            files: {
+                                workflow: workflowFilePath,
+                                componentSpec: componentJsonDir
+                            },
+                            message: 'Component development files successfully created',
+                            rules: [
+                                `Follow the component workflow process defined in file://${workflowFilePath} for structured development. This workflow contains a lot of content, you'll need to read it in multiple sessions.`,
+                                `Implement the component according to the specifications in file://${componentJsonDir}, ensuring all properties and states are properly handled.`
+                            ]
+                        })
+                    }
+                ]
+            };
+        } catch (error: any) {
+            const errorMessage = error.response?.data ?? error?.message;
+            return {
+                isError: true,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(errorMessage)
+                    }
+                ]
+            };
+        }
     }
-
-    fs.writeFileSync(componentJsonDir, JSON.stringify(jsonData[0]));
-
-    try {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              files: {
-                workflow: workflowFilePath,
-                componentSpec: componentJsonDir,
-              },
-              message: "Component development files successfully created",
-              rules: [
-                `Follow the component workflow process defined in file://${workflowFilePath} for structured development. This workflow contains a lot of content, you'll need to read it in multiple sessions.`,
-                `Implement the component according to the specifications in file://${componentJsonDir}, ensuring all properties and states are properly handled.`,
-              ],
-            }),
-          },
-        ],
-      };
-    } catch (error: any) {
-      const errorMessage = error.response?.data ?? error?.message;
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(errorMessage),
-          },
-        ],
-      };
-    }
-  }
 }

--- a/src/tools/get-d2c.ts
+++ b/src/tools/get-d2c.ts
@@ -1,12 +1,12 @@
-import { z } from "zod";
-import { BaseTool } from "./base-tool";
-import { httpUtilInstance } from "../utils/api";
-import axios from "axios";
-import path from "path";
-import { existsSync, mkdirSync } from "fs";
-import { writeFile } from "fs/promises";
+import axios from 'axios';
+import { existsSync, mkdirSync } from 'fs';
+import { writeFile } from 'fs/promises';
+import path from 'path';
+import { z } from 'zod';
+import { httpUtilInstance } from '../utils/api';
+import { BaseTool } from './base-tool';
 
-const D2C_TOOL_NAME = "mcp__getD2c";
+const D2C_TOOL_NAME = 'mcp__getD2c';
 const D2C_TOOL_DESCRIPTION = `
 使用此工具从 MasterGo 获取 D2C 数据，并在本地落盘：
 1）将返回的 code 写入 html；
@@ -14,328 +14,311 @@ const D2C_TOOL_DESCRIPTION = `
 3）返回落盘摘要，避免把大体积资源塞进上下文。
 `;
 
-type ResourcePathMap = Record<"image" | "svg", string>;
+type ResourcePathMap = Record<'image' | 'svg', string>;
 
 type SaveResult = {
-  targetDir: string;
-  htmlFileName: string;
-  htmlPath: string;
-  svgCount: number;
-  imageCount: number;
-  resourcePathMap: ResourcePathMap;
+    targetDir: string;
+    htmlFileName: string;
+    htmlPath: string;
+    svgCount: number;
+    imageCount: number;
+    resourcePathMap: ResourcePathMap;
 };
 
 type WriteResourceResult = {
-  savedCount: number;
-  attemptedCount: number;
-  errorCount: number;
+    savedCount: number;
+    attemptedCount: number;
+    errorCount: number;
 };
 
 function isEmpty(value: any): boolean {
-  if (value === null || value === undefined) return true;
-  if (typeof value === "string") return value.trim().length === 0;
-  if (Array.isArray(value)) return value.length === 0;
-  if (typeof value === "object") return Object.keys(value).length === 0;
-  return false;
+    if (value === null || value === undefined) return true;
+    if (typeof value === 'string') return value.trim().length === 0;
+    if (Array.isArray(value)) return value.length === 0;
+    if (typeof value === 'object') return Object.keys(value).length === 0;
+    return false;
 }
 
 function hasContent(value: any): boolean {
-  if (value === null || value === undefined) return false;
-  if (typeof value === "string") return value.trim().length > 0;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === "object") return Object.keys(value).length > 0;
-  return false;
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.trim().length > 0;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return false;
 }
 
 function pickFirstWithContent(values: any[]): any {
-  for (const v of values) {
-    if (hasContent(v)) return v;
-  }
-  return undefined;
+    for (const v of values) {
+        if (hasContent(v)) return v;
+    }
+    return undefined;
 }
 
 function parseResourcePath(resourcePath: any): ResourcePathMap {
-  const map: ResourcePathMap = {
-    image: "asset/images",
-    svg: "asset/icons",
-  };
-  if (!isEmpty(resourcePath)) {
-    try {
-      const parsed = typeof resourcePath === "string" ? JSON.parse(resourcePath) : resourcePath;
-      if (parsed.image) {
-        map.image = String(parsed.image)
-          .replace(/^(\.\/|\/)/, "")
-          .replace(/\/+$/, "");
-      }
-      if (parsed.svg) {
-        map.svg = String(parsed.svg).replace(/^(\.\/|\/)/, "").replace(/\/+$/, "");
-      }
-    } catch {
-      return map;
+    const map: ResourcePathMap = {
+        image: 'asset/images',
+        svg: 'asset/icons'
+    };
+    if (!isEmpty(resourcePath)) {
+        try {
+            const parsed = typeof resourcePath === 'string' ? JSON.parse(resourcePath) : resourcePath;
+            if (parsed.image) {
+                map.image = String(parsed.image)
+                    .replace(/^(\.\/|\/)/, '')
+                    .replace(/\/+$/, '');
+            }
+            if (parsed.svg) {
+                map.svg = String(parsed.svg)
+                    .replace(/^(\.\/|\/)/, '')
+                    .replace(/\/+$/, '');
+            }
+        } catch {
+            return map;
+        }
     }
-  }
-  return map;
+    return map;
 }
 
 async function writeResource(
-  resData: any,
-  targetDir: string,
-  folderName: string,
-  ext: string
+    resData: any,
+    targetDir: string,
+    folderName: string,
+    ext: string
 ): Promise<WriteResourceResult> {
-  if (isEmpty(resData)) return { savedCount: 0, attemptedCount: 0, errorCount: 0 };
+    if (isEmpty(resData)) return { savedCount: 0, attemptedCount: 0, errorCount: 0 };
 
-  let parsed: any;
-  try {
-    parsed = typeof resData === "string" ? JSON.parse(resData) : resData;
-  } catch {
-    return { savedCount: 0, attemptedCount: 0, errorCount: 1 };
-  }
+    let parsed: any;
+    try {
+        parsed = typeof resData === 'string' ? JSON.parse(resData) : resData;
+    } catch {
+        return { savedCount: 0, attemptedCount: 0, errorCount: 1 };
+    }
 
-  if (!parsed || typeof parsed !== "object") {
-    return { savedCount: 0, attemptedCount: 0, errorCount: 1 };
-  }
+    if (!parsed || typeof parsed !== 'object') {
+        return { savedCount: 0, attemptedCount: 0, errorCount: 1 };
+    }
 
-  const keys = Object.keys(parsed);
-  if (keys.length === 0) {
-    return { savedCount: 0, attemptedCount: 0, errorCount: 0 };
-  }
+    const keys = Object.keys(parsed);
+    if (keys.length === 0) {
+        return { savedCount: 0, attemptedCount: 0, errorCount: 0 };
+    }
 
-  const resDir = path.join(targetDir, folderName);
-  if (!existsSync(resDir)) mkdirSync(resDir, { recursive: true });
+    const resDir = path.join(targetDir, folderName);
+    if (!existsSync(resDir)) mkdirSync(resDir, { recursive: true });
 
-  let successCount = 0;
-  let errorCount = 0;
+    let successCount = 0;
+    let errorCount = 0;
 
-  await Promise.all(
-    Object.entries(parsed).map(async ([key, value]) => {
-      const match = String(key).match(/(.+)\.([a-zA-Z0-9]+)$/);
-      const safeKey = (match ? match[1] : key).replace(/[^a-zA-Z0-9_-]/g, "_");
-      const finalExt = match ? match[2] : ext;
-      const filePath = path.join(resDir, `${safeKey}.${finalExt}`);
+    await Promise.all(
+        Object.entries(parsed).map(async ([key, value]) => {
+            const match = String(key).match(/(.+)\.([a-zA-Z0-9]+)$/);
+            const safeKey = (match ? match[1] : key).replace(/[^a-zA-Z0-9_-]/g, '_');
+            const finalExt = match ? match[2] : ext;
+            const filePath = path.join(resDir, `${safeKey}.${finalExt}`);
 
-      const content = value as any;
+            const content = value as any;
 
-      try {
-        if (typeof content === "string" && content.startsWith("http")) {
-          try {
-            const response = await axios.get(content, {
-              responseType: "arraybuffer",
-              timeout: 30000,
-            });
-            await writeFile(filePath, response.data);
-            successCount += 1;
-            return;
-          } catch (err: any) {
-            const isWrongSsl =
-              err?.code === "EPROTO" ||
-              String(err?.message ?? "").includes("wrong version number");
+            try {
+                if (typeof content === 'string' && content.startsWith('http')) {
+                    try {
+                        const response = await axios.get(content, {
+                            responseType: 'arraybuffer',
+                            timeout: 30_000
+                        });
+                        await writeFile(filePath, response.data);
+                        successCount += 1;
+                        return;
+                    } catch (err: any) {
+                        const isWrongSsl =
+                            err?.code === 'EPROTO' || String(err?.message ?? '').includes('wrong version number');
 
-            // 有些资源链接会误把 http 服务包装成 https，导致 EPROTO：
-            // 尝试回退到 http 再请求一次。
-            if (isWrongSsl && content.startsWith("https://")) {
-              const httpUrl = content.replace(/^https:\/\//, "http://");
-              const response = await axios.get(httpUrl, {
-                responseType: "arraybuffer",
-                timeout: 30000,
-              });
-              await writeFile(filePath, response.data);
-              successCount += 1;
-              return;
+                        // 有些资源链接会误把 http 服务包装成 https，导致 EPROTO：
+                        // 尝试回退到 http 再请求一次。
+                        if (isWrongSsl && content.startsWith('https://')) {
+                            const httpUrl = content.replace(/^https:\/\//, 'http://');
+                            const response = await axios.get(httpUrl, {
+                                responseType: 'arraybuffer',
+                                timeout: 30_000
+                            });
+                            await writeFile(filePath, response.data);
+                            successCount += 1;
+                            return;
+                        }
+
+                        errorCount += 1;
+                        return;
+                    }
+                }
+
+                if (typeof content === 'string' && content.startsWith('data:image/')) {
+                    const parts = content.split(';base64,');
+                    if (parts.length === 2) {
+                        await writeFile(filePath, parts[1], 'base64');
+                        successCount += 1;
+                    }
+                    return;
+                }
+
+                const dataToWrite =
+                    typeof content === 'object' ? JSON.stringify(content, null, 2) : String(content ?? '');
+                const encoding: BufferEncoding =
+                    finalExt === 'png' || finalExt === 'jpg' || finalExt === 'jpeg' ? 'base64' : 'utf8';
+                await writeFile(filePath, dataToWrite, encoding);
+                successCount += 1;
+            } catch {
+                errorCount += 1;
+                return;
             }
+        })
+    );
 
-            errorCount += 1;
-            return;
-          }
-        }
-
-        if (typeof content === "string" && content.startsWith("data:image/")) {
-          const parts = content.split(";base64,");
-          if (parts.length === 2) {
-            await writeFile(filePath, parts[1], "base64");
-            successCount += 1;
-          }
-          return;
-        }
-
-        const dataToWrite =
-          typeof content === "object" ? JSON.stringify(content, null, 2) : String(content ?? "");
-        const encoding: BufferEncoding =
-          finalExt === "png" || finalExt === "jpg" || finalExt === "jpeg" ? "base64" : "utf8";
-        await writeFile(filePath, dataToWrite, encoding);
-        successCount += 1;
-      } catch {
-        errorCount += 1;
-        return;
-      }
-    })
-  );
-
-  return { savedCount: successCount, attemptedCount: keys.length, errorCount };
+    return { savedCount: successCount, attemptedCount: keys.length, errorCount };
 }
 
 async function saveCodeAndResources(params: {
-  outDir?: string;
-  contentId: string;
-  code: string;
-  resourcePath?: any;
-  svg?: any;
-  image?: any;
+    outDir?: string;
+    contentId: string;
+    code: string;
+    resourcePath?: any;
+    svg?: any;
+    image?: any;
 }): Promise<SaveResult> {
-  const { outDir, contentId, code, resourcePath, svg, image } = params;
+    const { outDir, contentId, code, resourcePath, svg, image } = params;
 
-  const targetDir = outDir
-    ? path.isAbsolute(outDir)
-      ? path.join(outDir)
-      : path.join(process.cwd(), outDir)
-    : process.cwd();
+    const targetDir = outDir
+        ? path.isAbsolute(outDir)
+            ? path.join(outDir)
+            : path.join(process.cwd(), outDir)
+        : process.cwd();
 
-  if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
+    if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
 
-  const htmlFileName = `${contentId || "index"}.html`;
-  const htmlPath = path.join(targetDir, htmlFileName);
+    const htmlFileName = `${contentId || 'index'}.html`;
+    const htmlPath = path.join(targetDir, htmlFileName);
 
-  if (!isEmpty(code)) {
-    await writeFile(htmlPath, code, "utf8");
-  }
+    if (!isEmpty(code)) {
+        await writeFile(htmlPath, code, 'utf8');
+    }
 
-  const resPathMap = parseResourcePath(resourcePath);
+    const resPathMap = parseResourcePath(resourcePath);
 
-  // 即使资源为空，也确保目录按 resourcePath 规划创建出来，便于后续排查
-  const ensureResDir = (folderName: string) => {
-    const dirPath = path.join(targetDir, folderName);
-    if (!existsSync(dirPath)) mkdirSync(dirPath, { recursive: true });
-  };
-  ensureResDir(resPathMap.image);
-  ensureResDir(resPathMap.svg);
+    // 即使资源为空，也确保目录按 resourcePath 规划创建出来，便于后续排查
+    const ensureResDir = (folderName: string) => {
+        const dirPath = path.join(targetDir, folderName);
+        if (!existsSync(dirPath)) mkdirSync(dirPath, { recursive: true });
+    };
+    ensureResDir(resPathMap.image);
+    ensureResDir(resPathMap.svg);
 
+    const [svgWrite, imageWrite] = await Promise.all([
+        writeResource(svg, targetDir, resPathMap.svg, 'svg'),
+        writeResource(image, targetDir, resPathMap.image, 'png')
+    ]);
 
-  const [svgWrite, imageWrite] = await Promise.all([
-    writeResource(svg, targetDir, resPathMap.svg, "svg"),
-    writeResource(image, targetDir, resPathMap.image, "png"),
-  ]);
-
-  return {
-    targetDir,
-    htmlFileName,
-    htmlPath,
-    svgCount: svgWrite.savedCount,
-    imageCount: imageWrite.savedCount,
-    resourcePathMap: resPathMap,
-  };
+    return {
+        targetDir,
+        htmlFileName,
+        htmlPath,
+        svgCount: svgWrite.savedCount,
+        imageCount: imageWrite.savedCount,
+        resourcePathMap: resPathMap
+    };
 }
 
 function extractPayload(d2c: any): {
-  contentId: string;
-  frameType?: string;
-  code: string;
-  resourcePath?: any;
-  shape?: any;
-  svg?: any;
-  image?: any;
+    contentId: string;
+    frameType?: string;
+    code: string;
+    resourcePath?: any;
+    shape?: any;
+    svg?: any;
+    image?: any;
 } {
-  const data = d2c?.data;
-  const firstItem = Array.isArray(data) ? data[0] : undefined;
+    const data = d2c?.data;
+    const firstItem = Array.isArray(data) ? data[0] : undefined;
 
-  const payload =
-    firstItem?.payload ??
-    d2c?.payload ??
-    d2c?.data?.payload ??
-    firstItem?.payload?.payload ??
-    data?.payload ??
-    {};
+    const payload =
+        firstItem?.payload ?? d2c?.payload ?? d2c?.data?.payload ?? firstItem?.payload?.payload ?? data?.payload ?? {};
 
-  const codeCandidate =
-    payload?.code ?? payload?.html ?? payload?.content ?? d2c?.code ?? "";
+    const codeCandidate = payload?.code ?? payload?.html ?? payload?.content ?? d2c?.code ?? '';
 
-  const resourcePath = pickFirstWithContent([
-    payload?.resourcePath,
-    d2c?.resourcePath,
-    firstItem?.resourcePath,
-  ]);
+    const resourcePath = pickFirstWithContent([payload?.resourcePath, d2c?.resourcePath, firstItem?.resourcePath]);
 
-  const image = pickFirstWithContent([payload?.image, firstItem?.image]);
-  const svg = pickFirstWithContent([payload?.svg, firstItem?.svg]);
-  const shape = pickFirstWithContent([payload?.shape, firstItem?.shape]);
+    const image = pickFirstWithContent([payload?.image, firstItem?.image]);
+    const svg = pickFirstWithContent([payload?.svg, firstItem?.svg]);
+    const shape = pickFirstWithContent([payload?.shape, firstItem?.shape]);
 
-  return {
-    contentId: String(firstItem?.contentId ?? payload?.contentId ?? d2c?.contentId ?? ""),
-    frameType: payload?.frameType ?? firstItem?.frameType ?? d2c?.frameType,
-    code: String(codeCandidate ?? ""),
-    resourcePath,
-    shape,
-    svg,
-    image,
-  };
+    return {
+        contentId: String(firstItem?.contentId ?? payload?.contentId ?? d2c?.contentId ?? ''),
+        frameType: payload?.frameType ?? firstItem?.frameType ?? d2c?.frameType,
+        code: String(codeCandidate ?? ''),
+        resourcePath,
+        shape,
+        svg,
+        image
+    };
 }
 
 export class GetD2cTool extends BaseTool {
-  name = D2C_TOOL_NAME;
-  description = D2C_TOOL_DESCRIPTION;
+    name = D2C_TOOL_NAME;
+    description = D2C_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
-
-  schema = z.object({
-    contentId: z
-      .string()
-      .describe(
-        "MasterGo D2C contentId，例如 mastergo://getd2c/176452330285910-2-2845 中的 176452330285910-2-2845。"
-      ),
-    documentId: z
-      .string()
-      .describe(
-        "MasterGo 文档 ID，通常为 contentId 的第一段，例如 contentId 为 176452330285910-2-9032 时 documentId 为 176452330285910。"
-      ),
-    outDir: z
-      .string()
-      .optional()
-      .describe("可选，输出目录（绝对路径或相对当前工作目录）。"),
-  });
-
-  async execute({
-    contentId,
-    documentId,
-    outDir,
-  }: z.infer<typeof this.schema>) {
-    try {
-      if (!contentId) throw new Error("contentId 不能为空");
-      if (!documentId) throw new Error("documentId 不能为空");
-
-      const d2c = await httpUtilInstance.getD2c(contentId, documentId);
-
-      const payloadExtracted = extractPayload(d2c);
-      const finalContentId = payloadExtracted.contentId || contentId;
-
-      await saveCodeAndResources({
-        outDir,
-        contentId: finalContentId,
-        code: payloadExtracted.code,
-        resourcePath: payloadExtracted.resourcePath,
-        svg: payloadExtracted.svg,
-        image: payloadExtracted.image,
-      });
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(d2c),
-          },
-        ],
-      };
-    } catch (error: any) {
-      const errorMessage = error?.response?.data ?? error?.message;
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(errorMessage),
-          },
-        ],
-      };
+    constructor() {
+        super();
     }
-  }
+
+    schema = z.object({
+        contentId: z
+            .string()
+            .describe(
+                'MasterGo D2C contentId，例如 mastergo://getd2c/176452330285910-2-2845 中的 176452330285910-2-2845。'
+            ),
+        documentId: z
+            .string()
+            .describe(
+                'MasterGo 文档 ID，通常为 contentId 的第一段，例如 contentId 为 176452330285910-2-9032 时 documentId 为 176452330285910。'
+            ),
+        outDir: z.string().optional().describe('可选，输出目录（绝对路径或相对当前工作目录）。')
+    });
+
+    async execute({ contentId, documentId, outDir }: z.infer<typeof this.schema>) {
+        try {
+            if (!contentId) throw new Error('contentId 不能为空');
+            if (!documentId) throw new Error('documentId 不能为空');
+
+            const d2c = await httpUtilInstance.getD2c(contentId, documentId);
+
+            const payloadExtracted = extractPayload(d2c);
+            const finalContentId = payloadExtracted.contentId || contentId;
+
+            await saveCodeAndResources({
+                outDir,
+                contentId: finalContentId,
+                code: payloadExtracted.code,
+                resourcePath: payloadExtracted.resourcePath,
+                svg: payloadExtracted.svg,
+                image: payloadExtracted.image
+            });
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(d2c)
+                    }
+                ]
+            };
+        } catch (error: any) {
+            const errorMessage = error?.response?.data ?? error?.message;
+            return {
+                isError: true,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(errorMessage)
+                    }
+                ]
+            };
+        }
+    }
 }

--- a/src/tools/get-dsl.ts
+++ b/src/tools/get-dsl.ts
@@ -1,8 +1,8 @@
-import { z } from "zod";
-import { BaseTool } from "./base-tool";
-import { httpUtilInstance } from "../utils/api";
+import { z } from 'zod';
+import { httpUtilInstance } from '../utils/api';
+import { BaseTool } from './base-tool';
 
-const DSL_TOOL_NAME = "mcp__getDsl";
+const DSL_TOOL_NAME = 'mcp__getDsl';
 const DSL_TOOL_DESCRIPTION = `
 "Use this tool to retrieve the DSL (Domain Specific Language) data from MasterGo design files and the rules you must follow when generating code.
 This tool is useful when you need to analyze the structure of a design, understand component hierarchy, or extract design properties.
@@ -15,88 +15,82 @@ The DSL data can also be used to transform and generate code for different frame
 `;
 
 export class GetDslTool extends BaseTool {
-  name = DSL_TOOL_NAME;
-  description = DSL_TOOL_DESCRIPTION;
+    name = DSL_TOOL_NAME;
+    description = DSL_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
-
-  schema = z.object({
-    fileId: z
-      .string()
-      .optional()
-      .describe(
-        "MasterGo design file ID (format: file/<fileId> in MasterGo URL). Required if shortLink is not provided."
-      ),
-    layerId: z
-      .string()
-      .optional()
-      .describe(
-        "Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId> / file=<fileId> in MasterGo URL). Required if shortLink is not provided."
-      ),
-    sourceLayerId: z
-      .string()
-      .optional()
-      .describe(
-        "Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries."
-      ),
-    shortLink: z
-      .string()
-      .optional()
-      .describe("Short link (like https://{domain}/goto/LhGgBAK)."),
-  });
-
-  async execute({ fileId, layerId, sourceLayerId, shortLink }: z.infer<typeof this.schema>) {
-    try {
-      if (!shortLink && (!fileId || !layerId)) {
-        throw new Error(
-          "Either provide both fileId and layerId, or provide a MasterGo URL"
-        );
-      }
-
-      let finalFileId = this.normalizeFileId(fileId);
-      let finalLayerId = layerId;
-      let finalSourceLayerId = sourceLayerId;
-
-      // If URL is provided, extract fileId and layerId from it
-      if (shortLink) {
-        const ids = await httpUtilInstance.extractIdsFromUrl(shortLink);
-        finalFileId = this.normalizeFileId(ids.fileId);
-        finalLayerId = ids.layerId;
-        finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
-      }
-
-      if (!finalFileId || !finalLayerId) {
-        throw new Error("Could not determine fileId or layerId");
-      }
-
-      const dsl = await httpUtilInstance.getDsl(finalFileId, finalLayerId, finalSourceLayerId);
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(dsl),
-          },
-        ],
-      };
-    } catch (error: any) {
-      const errorMessage = error.response?.data ?? error?.message;
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(errorMessage),
-          },
-        ],
-      };
+    constructor() {
+        super();
     }
-  }
 
-  private normalizeFileId(fileId?: string) {
-    if (!fileId) return fileId;
-    return fileId.replace(/^file\//, "");
-  }
+    schema = z.object({
+        fileId: z
+            .string()
+            .optional()
+            .describe(
+                'MasterGo design file ID (format: file/<fileId> in MasterGo URL). Required if shortLink is not provided.'
+            ),
+        layerId: z
+            .string()
+            .optional()
+            .describe(
+                'Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId> / file=<fileId> in MasterGo URL). Required if shortLink is not provided.'
+            ),
+        sourceLayerId: z
+            .string()
+            .optional()
+            .describe(
+                'Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries.'
+            ),
+        shortLink: z.string().optional().describe('Short link (like https://{domain}/goto/LhGgBAK).')
+    });
 
+    async execute({ fileId, layerId, sourceLayerId, shortLink }: z.infer<typeof this.schema>) {
+        try {
+            if (!shortLink && !(fileId && layerId)) {
+                throw new Error('Either provide both fileId and layerId, or provide a MasterGo URL');
+            }
+
+            let finalFileId = this.normalizeFileId(fileId);
+            let finalLayerId = layerId;
+            let finalSourceLayerId = sourceLayerId;
+
+            // If URL is provided, extract fileId and layerId from it
+            if (shortLink) {
+                const ids = await httpUtilInstance.extractIdsFromUrl(shortLink);
+                finalFileId = this.normalizeFileId(ids.fileId);
+                finalLayerId = ids.layerId;
+                finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
+            }
+
+            if (!(finalFileId && finalLayerId)) {
+                throw new Error('Could not determine fileId or layerId');
+            }
+
+            const dsl = await httpUtilInstance.getDsl(finalFileId, finalLayerId, finalSourceLayerId);
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(dsl)
+                    }
+                ]
+            };
+        } catch (error: any) {
+            const errorMessage = error.response?.data ?? error?.message;
+            return {
+                isError: true,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(errorMessage)
+                    }
+                ]
+            };
+        }
+    }
+
+    private normalizeFileId(fileId?: string) {
+        if (!fileId) return fileId;
+        return fileId.replace(/^file\//, '');
+    }
 }

--- a/src/tools/get-meta.ts
+++ b/src/tools/get-meta.ts
@@ -1,9 +1,9 @@
-import { z } from "zod";
-import { BaseTool } from "./base-tool";
-import { httpUtilInstance } from "../utils/api";
-import rules from "../markdown/meta.md";
+import { z } from 'zod';
+import rules from '../markdown/meta.md';
+import { httpUtilInstance } from '../utils/api';
+import { BaseTool } from './base-tool';
 
-const META_TOOL_NAME = "mcp__getMeta";
+const META_TOOL_NAME = 'mcp__getMeta';
 const META_TOOL_DESCRIPTION = `
 Use this tool when the user intends to build a complete website or needs to obtain high-level site
 configuration information. You must provide a fileld and layerld to identify the specific design element.
@@ -12,57 +12,53 @@ follow the rules and use the results to analyze the site and page.
 `;
 
 export class GetMetaTool extends BaseTool {
-  name = META_TOOL_NAME;
-  description = META_TOOL_DESCRIPTION;
+    name = META_TOOL_NAME;
+    description = META_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
-
-  schema = z.object({
-    fileId: z
-      .string()
-      .describe(
-        "MasterGo design file ID (format: file/<fileId> in MasterGo URL)"
-      ),
-    layerId: z
-      .string()
-      .describe(
-        "Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId> / file=<fileId> in MasterGo URL)"
-      ),
-    sourceLayerId: z
-      .string()
-      .optional()
-      .describe(
-        "Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries."
-      ),
-  });
-
-  async execute({ fileId, layerId, sourceLayerId }: z.infer<typeof this.schema>) {
-    try {
-      const result = await httpUtilInstance.getMeta(fileId, layerId, sourceLayerId);
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              result,
-              rules,
-            }),
-          },
-        ],
-      };
-    } catch (error: any) {
-      const errorMessage = error.response?.data ?? error?.message;
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(errorMessage),
-          },
-        ],
-      };
+    constructor() {
+        super();
     }
-  }
+
+    schema = z.object({
+        fileId: z.string().describe('MasterGo design file ID (format: file/<fileId> in MasterGo URL)'),
+        layerId: z
+            .string()
+            .describe(
+                'Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId> / file=<fileId> in MasterGo URL)'
+            ),
+        sourceLayerId: z
+            .string()
+            .optional()
+            .describe(
+                'Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries.'
+            )
+    });
+
+    async execute({ fileId, layerId, sourceLayerId }: z.infer<typeof this.schema>) {
+        try {
+            const result = await httpUtilInstance.getMeta(fileId, layerId, sourceLayerId);
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify({
+                            result,
+                            rules
+                        })
+                    }
+                ]
+            };
+        } catch (error: any) {
+            const errorMessage = error.response?.data ?? error?.message;
+            return {
+                isError: true,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(errorMessage)
+                    }
+                ]
+            };
+        }
+    }
 }

--- a/src/tools/get-version.ts
+++ b/src/tools/get-version.ts
@@ -1,28 +1,28 @@
-import { z } from "zod";
-import { BaseTool } from "./base-tool";
-import packageJson from "../../package.json";
+import { z } from 'zod';
+import packageJson from '../../package.json';
+import { BaseTool } from './base-tool';
 
 const VERSION_TOOL_NAME = `version_${packageJson.version.replace(/\./g, '_')}`;
 const VERSION_TOOL_DESCRIPTION = `the current version is ${packageJson.version}`;
 
 export class GetVersionTool extends BaseTool {
-  name = VERSION_TOOL_NAME;
-  description = VERSION_TOOL_DESCRIPTION;
+    name = VERSION_TOOL_NAME;
+    description = VERSION_TOOL_DESCRIPTION;
 
-  constructor() {
-    super();
-  }
+    constructor() {
+        super();
+    }
 
-  schema = z.object({});
+    schema = z.object({});
 
-  async execute({}: z.infer<typeof this.schema>) {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify(packageJson.version),
-        },
-      ],
-    };
-  }
+    async execute({}: z.infer<typeof this.schema>) {
+        return {
+            content: [
+                {
+                    type: 'text' as const,
+                    text: JSON.stringify(packageJson.version)
+                }
+            ]
+        };
+    }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
 declare module '*.md' {
-  const content: string;
-  export default content;
-} 
+    const content: string;
+    export default content;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,72 +1,103 @@
-import axios, { AxiosRequestConfig } from "axios";
-import { parseToken, parseUrl, parseRules, parseNoRule } from "./args";
-import https from "https";
+import axios, { type AxiosRequestConfig } from 'axios';
+import https from 'https';
+import { parseNoRule, parseRules, parseToken, parseUrl } from './args';
+import { requestTokenStore } from './request-context';
 
 axios.defaults.httpsAgent = new https.Agent({
-  rejectUnauthorized: false,
+    rejectUnauthorized: false
 });
+
+/** 避免 axios 错误对象序列化 / 日志打印时泄露访问令牌 */
+function stripSensitiveHeadersFromAxiosError(error: unknown): void {
+    const cfg = (error as { config?: { headers?: unknown } })?.config;
+    const headers = cfg?.headers;
+    if (headers == null) {
+        return;
+    }
+    if (typeof (headers as { delete?: (key: string) => void }).delete === 'function') {
+        (headers as { delete: (key: string) => void }).delete('X-MG-UserAccessToken');
+        (headers as { delete: (key: string) => void }).delete('Authorization');
+        return;
+    }
+    if (typeof headers === 'object') {
+        Reflect.deleteProperty(headers as object, 'X-MG-UserAccessToken');
+        Reflect.deleteProperty(headers as object, 'Authorization');
+    }
+}
+
+axios.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        stripSensitiveHeadersFromAxiosError(error);
+        return Promise.reject(error);
+    }
+);
 
 // DSL response interface
 export interface DslResponse {
-  [key: string]: any;
+    [key: string]: any;
 }
 
 // Code generation response interface
 export interface CodeResponse {
-  code: string;
-  [key: string]: any;
+    code: string;
+    [key: string]: any;
 }
 
-const getCommonHeader = () => ({
-  "Content-Type": "application/json",
-  Accept: "application/json",
-  "X-MG-UserAccessToken":
-    process.env.MG_MCP_TOKEN || process.env.MASTERGO_API_TOKEN || parseToken(),
-});
+const getCommonHeader = () => {
+    const fromRequest = requestTokenStore.getStore();
+    const token =
+        fromRequest != null && fromRequest.trim().length > 0
+            ? fromRequest.trim()
+            : process.env.MG_MCP_TOKEN || process.env.MASTERGO_API_TOKEN || parseToken();
+    return {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-MG-UserAccessToken': token
+    };
+};
 
 const getBaseUrl = () => {
-  const url = process.env.API_BASE_URL || parseUrl();
-  try {
-    // 解析URL
-    const urlObj = new URL(url);
+    const url = process.env.API_BASE_URL || parseUrl();
+    try {
+        // 解析URL
+        const urlObj = new URL(url);
 
-    // 提取域名和协议
-    const protocol = urlObj.protocol;
-    const hostname = urlObj.hostname;
-    const port = urlObj.port;
+        // 提取域名和协议
+        const protocol = urlObj.protocol;
+        const hostname = urlObj.hostname;
+        const port = urlObj.port;
 
-    // 构建基础URL
-    let baseUrl = `${protocol}//${hostname}`;
-    if (port) {
-      baseUrl += `:${port}`;
+        // 构建基础URL
+        let baseUrl = `${protocol}//${hostname}`;
+        if (port) {
+            baseUrl += `:${port}`;
+        }
+
+        return baseUrl;
+    } catch {
+        throw new Error(`无效的URL格式: ${url}。请提供正确的URL格式，例如: https://mastergo.com`);
     }
-
-    return baseUrl;
-  } catch {
-    throw new Error(
-      `无效的URL格式: ${url}。请提供正确的URL格式，例如: https://mastergo.com`
-    );
-  }
 };
 
 const extractComponentDocumentLinks = (dsl: DslResponse): string[] => {
-  const documentLinks = new Set<string>();
+    const documentLinks = new Set<string>();
 
-  const traverse = (node: any) => {
-    if (node?.componentInfo?.componentSetDocumentLink?.[0]) {
-      documentLinks.add(node.componentInfo.componentSetDocumentLink[0]);
-    }
-    node.children?.forEach?.(traverse);
-  };
+    const traverse = (node: any) => {
+        if (node?.componentInfo?.componentSetDocumentLink?.[0]) {
+            documentLinks.add(node.componentInfo.componentSetDocumentLink[0]);
+        }
+        node.children?.forEach?.(traverse);
+    };
 
-  dsl.nodes?.forEach(traverse);
-  return Array.from(documentLinks);
+    dsl.nodes?.forEach(traverse);
+    return Array.from(documentLinks);
 };
 
 const buildDslRules = (): string[] => {
-  return [
-    "token filed must be generated as a variable (colors, shadows, fonts, etc.) and the token field must be displayed in the comment",
-    `componentDocumentLinks is a list of frontend component documentation links used in the DSL layer, designed to help you understand how to use the components.
+    return [
+        'token filed must be generated as a variable (colors, shadows, fonts, etc.) and the token field must be displayed in the comment',
+        `componentDocumentLinks is a list of frontend component documentation links used in the DSL layer, designed to help you understand how to use the components.
 When it exists and is not empty, you need to use mcp__getComponentLink in a for loop to get the URL content of all components in the list, understand how to use the components, and generate code using the components.
 For example: 
   \`\`\`js  
@@ -79,121 +110,115 @@ For example:
       console.log(componentLink);
     }
   \`\`\``,
-    ...(JSON.parse(process.env.RULES ?? "[]") as string[]),
-    ...parseRules(),
-  ];
+        ...(JSON.parse(process.env.RULES ?? '[]') as string[]),
+        ...parseRules()
+    ];
 };
 
 /**
  * Create HTTP utility functions with configured baseUrl and token
  */
 const createHttpUtil = () => {
-  return {
-    async getMeta(fileId: string, layerId: string, sourceLayerId?: string): Promise<string> {
-      const response = await axios.get(`${getBaseUrl()}/mcp/meta`, {
-        timeout: 30000,
-        params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
-        headers: getCommonHeader(),
-      });
-      return response.data;
-    },
+    return {
+        async getMeta(fileId: string, layerId: string, sourceLayerId?: string): Promise<string> {
+            const response = await axios.get(`${getBaseUrl()}/mcp/meta`, {
+                timeout: 30_000,
+                params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
+                headers: getCommonHeader()
+            });
+            return response.data;
+        },
 
-    async getDsl(fileId: string, layerId: string, sourceLayerId?: string): Promise<DslResponse> {
-      const response = await axios.get(`${getBaseUrl()}/mcp/dsl`, {
-        timeout: 30000,
-        params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
-        headers: getCommonHeader(),
-      });
+        async getDsl(fileId: string, layerId: string, sourceLayerId?: string): Promise<DslResponse> {
+            const response = await axios.get(`${getBaseUrl()}/mcp/dsl`, {
+                timeout: 30_000,
+                params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
+                headers: getCommonHeader()
+            });
 
-      return {
-        dsl: response.data,
-        componentDocumentLinks: extractComponentDocumentLinks(response.data),
-        rules: parseNoRule() ? [] : buildDslRules(),
-      };
-    },
+            return {
+                dsl: response.data,
+                componentDocumentLinks: extractComponentDocumentLinks(response.data),
+                rules: parseNoRule() ? [] : buildDslRules()
+            };
+        },
 
-    async getD2c(contentId: string,documentId: string): Promise<DslResponse> {
-      const params: Record<string, any> = { contentId: contentId, documentId: documentId };
-      const response = await axios.get(`${getBaseUrl()}/mcp/d2c/events`, {
-        timeout: 30000,
-        params,
-        headers: getCommonHeader(),
-      });
+        async getD2c(contentId: string, documentId: string): Promise<DslResponse> {
+            const params: Record<string, any> = { contentId, documentId };
+            const response = await axios.get(`${getBaseUrl()}/mcp/d2c/events`, {
+                timeout: 30_000,
+                params,
+                headers: getCommonHeader()
+            });
 
-      return response.data;
-    },
+            return response.data;
+        },
 
-    async postC2d(
-      data: string | Record<string, any>,
-      fileId?: string,
-      layerId?: string
-    ): Promise<any> {
-      const response = await axios.post(
-        `${getBaseUrl()}/mcp/c2d`,
-        { data, fileId, layerId },
-        {
-          timeout: 30000,
-          headers: getCommonHeader(),
+        async postC2d(data: string | Record<string, any>, fileId?: string, layerId?: string): Promise<any> {
+            const response = await axios.post(
+                `${getBaseUrl()}/mcp/c2d`,
+                { data, fileId, layerId },
+                {
+                    timeout: 30_000,
+                    headers: getCommonHeader()
+                }
+            );
+            return response.data;
+        },
+
+        async getComponentStyleJson(fileId: string, layerId: string, sourceLayerId?: string) {
+            const response = await axios.get(`${getBaseUrl()}/mcp/style`, {
+                timeout: 30_000,
+                params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
+                headers: getCommonHeader()
+            });
+            return response.data;
+        },
+
+        async request<T = any>(config: AxiosRequestConfig): Promise<T> {
+            const response = await axios.request({
+                ...config,
+                headers: { ...getCommonHeader(), ...config.headers }
+            });
+            return response.data;
+        },
+        /**
+         * Extract fileId and layerId from a MasterGo URL
+         */
+        async extractIdsFromUrl(url: string): Promise<{ fileId: string; layerId: string; sourceLayerId?: string }> {
+            let targetUrl = url;
+
+            // Handle short links
+            if (url.includes('/goto/')) {
+                const response = await axios.get(url, {
+                    maxRedirects: 0,
+                    validateStatus: (status) => status >= 300 && status < 400
+                });
+
+                const redirectUrl = response.headers.location;
+                if (!redirectUrl) {
+                    throw new Error('No redirect URL found for short link');
+                }
+                targetUrl = new URL(redirectUrl, url).href;
+            }
+
+            // Parse the URL
+            const urlObj = new URL(targetUrl);
+            const pathSegments = urlObj.pathname.split('/');
+            const searchParams = new URLSearchParams(urlObj.search);
+
+            // Extract fileId and layerId
+            const fileId = pathSegments.find((segment) => /^\d+$/.test(segment));
+            const layerId = searchParams.get('layer_id');
+
+            if (!fileId) throw new Error('Could not extract fileId from URL');
+            if (!layerId) throw new Error('Could not extract layerId from URL');
+
+            const sourceLayerId = searchParams.get('source_layer_id') || undefined;
+
+            return { fileId, layerId, sourceLayerId };
         }
-      );
-      return response.data;
-    },
-
-    async getComponentStyleJson(fileId: string, layerId: string, sourceLayerId?: string) {
-      const response = await axios.get(`${getBaseUrl()}/mcp/style`, {
-        timeout: 30000,
-        params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
-        headers: getCommonHeader(),
-      });
-      return response.data;
-    },
-
-    async request<T = any>(config: AxiosRequestConfig): Promise<T> {
-      const response = await axios.request({
-        ...config,
-        headers: { ...getCommonHeader(), ...config.headers },
-      });
-      return response.data;
-    },
-    /**
-     * Extract fileId and layerId from a MasterGo URL
-     */
-    async extractIdsFromUrl(
-      url: string
-    ): Promise<{ fileId: string; layerId: string; sourceLayerId?: string }> {
-      let targetUrl = url;
-
-      // Handle short links
-      if (url.includes("/goto/")) {
-        const response = await axios.get(url, {
-          maxRedirects: 0,
-          validateStatus: (status) => status >= 300 && status < 400,
-        });
-
-        const redirectUrl = response.headers.location;
-        if (!redirectUrl) {
-          throw new Error("No redirect URL found for short link");
-        }
-        targetUrl = new URL(redirectUrl, url).href;
-      }
-
-      // Parse the URL
-      const urlObj = new URL(targetUrl);
-      const pathSegments = urlObj.pathname.split("/");
-      const searchParams = new URLSearchParams(urlObj.search);
-
-      // Extract fileId and layerId
-      const fileId = pathSegments.find((segment) => /^\d+$/.test(segment));
-      const layerId = searchParams.get("layer_id");
-
-      if (!fileId) throw new Error("Could not extract fileId from URL");
-      if (!layerId) throw new Error("Could not extract layerId from URL");
-
-      const sourceLayerId = searchParams.get("source_layer_id") || undefined;
-
-      return { fileId, layerId, sourceLayerId };
-    },
-  };
+    };
 };
 
 export const httpUtilInstance = createHttpUtil();

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,100 +1,102 @@
 function getArgs(): string[] {
-  return process.argv.slice(2);
+    return process.argv.slice(2);
 }
 
 function parseToken(): string {
-  const args = getArgs();
-  let token = "";
+    const args = getArgs();
+    let token = '';
 
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--token" && i + 1 < args.length) {
-      token = args[i + 1];
-      break;
-    } else if (args[i].startsWith("--token=")) {
-      token = args[i].split("=")[1];
-      break;
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--token' && i + 1 < args.length) {
+            token = args[i + 1];
+            break;
+        }
+        if (args[i].startsWith('--token=')) {
+            token = args[i].split('=')[1];
+            break;
+        }
     }
-  }
 
-  return token;
+    return token;
 }
 
 function parseUrl(): string {
-  const args = getArgs();
-  let baseUrl = "";
+    const args = getArgs();
+    let baseUrl = '';
 
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--url" && i + 1 < args.length) {
-      baseUrl = args[i + 1];
-      break;
-    } else if (args[i].startsWith("--url=")) {
-      baseUrl = args[i].split("=")[1];
-      break;
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--url' && i + 1 < args.length) {
+            baseUrl = args[i + 1];
+            break;
+        }
+        if (args[i].startsWith('--url=')) {
+            baseUrl = args[i].split('=')[1];
+            break;
+        }
     }
-  }
 
-  return baseUrl;
+    return baseUrl;
 }
 
 function parseRules(): string[] {
-  const args = getArgs();
-  const rules: string[] = [];
+    const args = getArgs();
+    const rules: string[] = [];
 
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--rule" && i + 1 < args.length) {
-      rules.push(args[i + 1]);
-    } else if (args[i].startsWith("--rule=")) {
-      rules.push(args[i].split("=")[1]);
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--rule' && i + 1 < args.length) {
+            rules.push(args[i + 1]);
+        } else if (args[i].startsWith('--rule=')) {
+            rules.push(args[i].split('=')[1]);
+        }
     }
-  }
 
-  return rules;
+    return rules;
 }
 
 function parseDebug(): boolean {
-  const args = getArgs();
+    const args = getArgs();
 
-  for (const arg of args) {
-    if (arg === "--debug") {
-      return true;
+    for (const arg of args) {
+        if (arg === '--debug') {
+            return true;
+        }
     }
-  }
 
-  return false;
+    return false;
 }
 
 function parseNoRule(): boolean {
-  const args = getArgs();
+    const args = getArgs();
 
-  for (const arg of args) {
-    if (arg === "--no-rule") {
-      return true;
+    for (const arg of args) {
+        if (arg === '--no-rule') {
+            return true;
+        }
     }
-  }
 
-  return false;
+    return false;
 }
 
 export function parserArgs(): {
-  token: string;
-  baseUrl: string;
-  rules: string[];
-  debug: boolean;
-  noRule: boolean;
+    token: string;
+    baseUrl: string;
+    rules: string[];
+    debug: boolean;
+    noRule: boolean;
 } {
-  const token = parseToken();
-  const baseUrl = parseUrl();
-  const rules = parseRules();
-  const debug = parseDebug();
-  const noRule = parseNoRule();
+    const token = parseToken();
+    const baseUrl = parseUrl();
+    const rules = parseRules();
+    const debug = parseDebug();
+    const noRule = parseNoRule();
 
-  return {
-    token,
-    baseUrl,
-    rules,
-    debug,
-    noRule,
-  };
+    return {
+        token,
+        baseUrl,
+        rules,
+        debug,
+        noRule
+    };
 }
 
 export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, getArgs };

--- a/src/utils/request-context.ts
+++ b/src/utils/request-context.ts
@@ -1,0 +1,8 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * 单次 tools/call 请求内的 MasterGo API token。
+ * 由 BaseTool 在 handler 入口根据 MCP `extra._meta.userToken` 写入；
+ * HTTP 请求通过 `getCommonHeader()` 优先读取，未设置时回退 env / argv。
+ */
+export const requestTokenStore = new AsyncLocalStorage<string | undefined>();


### PR DESCRIPTION
Hosted MCP hosts can pass MasterGo API token per tools/call via extra._meta.userToken, using AsyncLocalStorage so startup --token/env remains fallback.