### PR TITLE
feat: add --proxy CLI argument support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "axios": "1.6.0",
+    "https-proxy-agent": "^9.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { parserArgs } from "./utils/args";
 // Main function
 function main() {
   // Parse command line arguments and set environment variables
-  const { token, baseUrl, rules, debug, noRule } = parserArgs();
+  const { token, baseUrl, rules, debug, noRule, proxy } = parserArgs();
 
   if (debug) {
     process.env.DEBUG = "true";
@@ -23,6 +23,7 @@ function main() {
     console.log(`API URL: ${baseUrl || "default"}`);
     console.log(`Rules: ${rules.length > 0 ? rules.join(", ") : "none"}`);
     console.log(`No Rule: ${noRule ? "enabled" : "disabled"}`);
+    console.log(`Proxy: ${proxy || "none"}`);
     console.log(`Debug mode: enabled`);
   }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,10 +1,31 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { parseToken, parseUrl, parseRules, parseNoRule } from "./args";
+import { parseToken, parseUrl, parseRules, parseNoRule, parseProxy } from "./args";
 import https from "https";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
-axios.defaults.httpsAgent = new https.Agent({
-  rejectUnauthorized: false,
-});
+// Configure proxy from --proxy arg or HTTP_PROXY/HTTPS_PROXY env vars
+const proxyUrl =
+  parseProxy() ||
+  process.env.HTTPS_PROXY ||
+  process.env.https_proxy ||
+  process.env.HTTP_PROXY ||
+  process.env.http_proxy;
+
+if (proxyUrl) {
+  try {
+    const proxyAgent = new HttpsProxyAgent(proxyUrl, {
+      rejectUnauthorized: false,
+    });
+    axios.defaults.httpAgent = proxyAgent;
+    axios.defaults.httpsAgent = proxyAgent;
+  } catch {
+    throw new Error(`Invalid proxy URL: ${proxyUrl}`);
+  }
+} else {
+  axios.defaults.httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+  });
+}
 
 // DSL response interface
 export interface DslResponse {

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -75,18 +75,37 @@ function parseNoRule(): boolean {
   return false;
 }
 
+function parseProxy(): string {
+  const args = getArgs();
+  let proxy = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--proxy" && i + 1 < args.length) {
+      proxy = args[i + 1];
+      break;
+    } else if (args[i].startsWith("--proxy=")) {
+      proxy = args[i].split("=")[1];
+      break;
+    }
+  }
+
+  return proxy;
+}
+
 export function parserArgs(): {
   token: string;
   baseUrl: string;
   rules: string[];
   debug: boolean;
   noRule: boolean;
+  proxy: string;
 } {
   const token = parseToken();
   const baseUrl = parseUrl();
   const rules = parseRules();
   const debug = parseDebug();
   const noRule = parseNoRule();
+  const proxy = parseProxy();
 
   return {
     token,
@@ -94,7 +113,8 @@ export function parserArgs(): {
     rules,
     debug,
     noRule,
+    proxy,
   };
 }
 
-export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, getArgs };
+export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseProxy, getArgs };


### PR DESCRIPTION
## 概述

支持 `--proxy` 参数，功能与 [Figma-Context-MCP](https://github.com/GLips/Figma-Context-MCP) 一致。

## 用法

```bash
# CLI 参数
node dist/index.js --token=YOUR_TOKEN --proxy=http://proxy.example.com:8080

# 带认证
node dist/index.js --token=YOUR_TOKEN --proxy=http://user:pass@proxy.example.com:8080

# 环境变量
HTTPS_PROXY=http://proxy.example.com:8080 node dist/index.js --token=YOUR_TOKEN
```

## 改动

- `src/utils/args.ts`：新增 `parseProxy()`
- `src/utils/api.ts`：使用 `https-proxy-agent` 配置代理，回退 `HTTPS_PROXY`/`HTTP_PROXY` 环境变量
- `src/index.ts`：`--debug` 输出代理信息
- `package.json`：新增 `https-proxy-agent` 依赖

已全面测试通过。