### PR TITLE
fix: add prepare script for GitHub install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "node build.js",
     "start": "node dist/index.js --token=test --url=http://localhost:3000 --debug",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## 问题

通过 GitHub 仓库安装时（如 `npm i mastergo-design/mastergo-magic-mcp#main`），npm 会执行 `prepare` 而不是 `prepublishOnly`，导致 `dist/` 目录不会构建，安装失败。

## 修复

添加 `prepare` 脚本，与 `prepublishOnly` 一致执行 `npm run build`。

- `prepublishOnly`：`npm publish` 时执行
- `prepare`：GitHub 安装及 `npm install -g` 时执行