### PR TITLE
fix: replace colons in layer ids when generating image urls

### DIFF
--- a/src/tools/get-component-workflow.ts
+++ b/src/tools/get-component-workflow.ts
@@ -54,7 +54,7 @@ export class GetComponentWorkflowTool extends BaseTool {
     const walkLayer = (layer: any) => {
       if (layer.path && layer.path.length > 0) {
         layer.imageUrls = [];
-        const id = layer.id.replaceAll("/", "&");
+        const id = layer.id.replaceAll("/", "&").replaceAll(":", "_");
         const imageDir = `${baseDir}/images`;
         if (!fs.existsSync(imageDir)) {
           fs.mkdirSync(imageDir, { recursive: true });


### PR DESCRIPTION
## Summary

修复 Windows 环境下 layer ID 中包含冒号（`:`）导致生成的图片 URL 路径无效的问题。

## Changes

- `src/tools/get-component-workflow.ts`：在生成图片 URL 时，将 layer ID 中的冒号替换为其他字符

## Test

- [x] Windows 环境下图片 URL 生成正常
- [x] 其他平台不受影响