### PR TITLE
Add npm source and issue metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@mastergo/magic-mcp",
   "version": "0.1.9-alpha.0",
   "description": "MasterGo MCP standalone service",
+  "homepage": "https://github.com/mastergo-design/mastergo-magic-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastergo-design/mastergo-magic-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mastergo-design/mastergo-magic-mcp/issues"
+  },
   "main": "dist/index.js",
   "bin": {
     "mastergo-magic-mcp": "dist/index.js"


### PR DESCRIPTION
## Summary
- add npm `homepage`, `repository`, and `bugs` metadata for `@mastergo/magic-mcp`
- point the package metadata at this repository and its issue tracker

## Why
The currently published `@mastergo/magic-mcp@0.1.9-alpha.0` package only returns `name` and `version` for:

```sh
npm view @mastergo/magic-mcp@0.1.9-alpha.0 name version homepage repository bugs --json
```

Adding these fields makes the source repository and issue tracker discoverable from npm and CLI package metadata tools.

## Validation
```sh
npm view @mastergo/magic-mcp@0.1.9-alpha.0 name version homepage repository bugs --json
node -e "const p=require('./package.json'); if(!p.homepage||!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.homepage); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts
git diff --check
```

`npm pack --dry-run --ignore-scripts` only reported the existing npm warning about the local `.npmrc` `node_modules` config.