### PR TITLE
feat(getDesignSections): enforce absolute positioning via per-section bbox and rootContainer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ const SERVER_INSTRUCTIONS = `
 ### Step 0: Get Layout Overview (MANDATORY)
 Call \`mcp__getDesignSections\` WITHOUT sectionIndex first.
 The response contains \`sections\` array with \`nodeCount\` per section, \`totalSections\`, and \`totalNodes\`.
+Each \`sections[]\` entry ALSO carries a **page-absolute bounding box**: \`x\`, \`y\` (top-left corner relative to the root container's origin), \`width\`, \`height\`. This tells you exactly where each section sits on the canvas.
 Use this to understand the design scope before fetching details.
 
 \`rootMetadata\` (if present) provides the root layer's dimensions (width, height), name, type, and optional fill/styles. Use these as the page frame size and background.
@@ -48,7 +49,9 @@ This returns exact text content for large text nodes (>50 chars). In the section
 
 ### Step 3: Generate Complete Code
 After ALL N sections have been fetched and SVG data retrieved:
-- Generate a single complete HTML file containing ALL sections in order.
+- MANDATORY: Use \`rootContainer\` from the section list response to create the root container div. Apply ALL its CSS properties (width, minHeight, background, overflow, position:relative) to a wrapping div. ALL sections MUST be placed inside this root container.
+- CRITICAL — Position each section ABSOLUTELY: every section entry has a page-absolute bbox (x, y, width, height) from Step 0. Wrap each section in a container with \`position:absolute; left:{x}px; top:{y}px; width:{width}px\` inside the root container. Do NOT reconstruct the page by stacking sections in a flex column with guessed \`margin-top\` / \`gap\` values. Many designs are spatially OVERLAID (status bar, title bar, form card, decorative curves, floating text, background layers) and only reconstruct correctly with absolute positioning. Intra-section layout still uses each node's \`layoutStyle.relativeX/relativeY\` as before.
+- Generate a single complete HTML file containing ALL sections in order, nested inside the root container.
 - token fields must be generated as CSS variables with comments indicating the token name.
 - If componentDocumentLinks exists, call mcp__getComponentLink to fetch documentation.
 

--- a/src/tools/get-design-sections.ts
+++ b/src/tools/get-design-sections.ts
@@ -7,9 +7,9 @@ const DESIGN_SECTIONS_TOOL_DESCRIPTION = `
 [PRIMARY] This is the main tool for all designs. Operates in TWO modes:
 
 Mode 1 — Get layout overview (sectionIndex NOT provided):
-Returns the list of all sections with id, name, type, and nodeCount, plus totalSections and totalNodes.
+Returns the list of all sections with id, name, type, nodeCount, and a page-absolute bounding box (x, y, width, height) for each section, plus totalSections and totalNodes.
 Also returns rootMetadata (root layer width/height/name/type/fill) when available.
-Use this FIRST to understand the design scope.
+Use this FIRST to understand the design scope. The per-section bbox tells you exactly where each section sits inside the root container — use it for absolute positioning when generating code.
 Example: { "fileId": "123", "layerId": "456:789" }
 
 Mode 2 — Get section DSL (sectionIndex provided):


### PR DESCRIPTION
## 变更摘要

强化 design-sections 的代码生成指导:section 列表已携带页面绝对 bbox（x/y/width/height），现要求生成代码时用 `rootContainer` 建根容器 + 每节绝对定位，禁止用 flex 列堆叠 + 猜测 margin/gap。

## 背景
design-sections 的 section 列表响应本就包含每个 section 的页面绝对 bbox，但 server instructions / 工具描述未要求据此做绝对定位。模型默认用 flex 列 + `margin-top`/`gap` 堆叠重建，对空间叠加式设计（状态栏、标题栏、表单卡片、装饰曲线、浮动文本、背景层）严重错位。

## 主要改动

### `src/index.ts`（SERVER_INSTRUCTIONS）
- **Step 0**：标注每个 `sections[]` entry 携带 page-absolute bbox（`x`/`y`/`width`/`height`），指示 section 在画布上的位置
- **Step 3**（生成代码）：
  - MANDATORY：用响应里的 `rootContainer` 建根容器 div，应用其全部 CSS（width/minHeight/background/overflow/`position:relative`），所有 section 放入其中
  - CRITICAL：每节用 `position:absolute; left:{x}px; top:{y}px; width:{width}px` 定位；禁止 flex 列堆叠 + 猜测 margin/gap；section 内部布局仍用各节点 `layoutStyle.relativeX/relativeY`

### `src/tools/get-design-sections.ts`（工具描述）
- Mode 1：补充说明返回每个 section 的 page-absolute bbox，强调用于绝对定位生成代码

## 文件变更

| # | 文件 | + | − | 说明 |
|---|------|---|---|------|
| 1 | src/index.ts | 4 | 1 | Step 0/3 强调 bbox + rootContainer 绝对定位 |
| 2 | src/tools/get-design-sections.ts | 2 | 2 | 工具描述补充 bbox 说明 |

## 说明
- 本次仅更新 server instructions 与工具描述文案，不改变 DSL 数据结构或运行时逻辑（bbox 数据已在响应中）
- 旨在让模型优先用绝对定位还原叠加式布局，减少 flex 堆叠导致的错位
