### PR TITLE
feat: add output format support for design data tools

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "ignorePatterns": ["dist/", "node_modules/", "build.js"],
+  "rules": {
+    // The codebase intentionally uses `any` for catch clauses and loose API shapes;
+    // flagging every `any` would drown out real issues. Surface as a warning instead.
+    "@typescript-eslint/no-explicit-any": "warn",
+    // Unused vars are real bugs — error on them, but ignore intentionally-unnamed args.
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "no-unused-vars": "off",
+    // Allow console.* (the client is a CLI; index.ts uses console for debug output).
+    "no-console": "off"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pnpm-lock.yaml
 dist/
 build/
 out/
+.test/
 
 .cursorrules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,21 @@
   - 工具描述（`*_TOOL_DESCRIPTION`）— 两个项目中对应的 tool 文件
 - 修改一处后，必须检查另一个项目的对应文件并同步变更。
 
+## 文档同步（README 双语）
+
+- 本项目同时维护 `README.md`（英文）和 `README.zh-CN.md`（中文），两份文档内容必须保持一致，仅语言不同。
+- **更新 `README.md` 时，必须同步更新 `README.zh-CN.md`**（反之亦然）。新增小节、修改参数说明、调整结构等任何内容变更都要在另一份文档中对应同步。
+- 检查清单：改动一处后，立即检查另一份文档的对应位置是否需要同步。
+
 ## Code Style
 
 - All imports must be placed at the top of the file. Do not use dynamic `import()` or write `import` statements in the middle of code.
 
 ## Build
 
+- **新增功能或依赖时，必须检查 `build.js` 是否需要同步更新**。检查项：`external` 列表（仅排除 Node 内建模块，所有第三方依赖默认打包）、`loader`、`entryPoints`、`target`、`resolveExtensions`、`minify`/`sourcemap`。
+  - 纯 JS 依赖（如 `js-yaml`）会随 `bundle: true` 自动打进 `dist/index.js`，无需改动 `build.js` —— 但仍必须**显式确认**它没有被误加进 `external`，且构建产物体积合理、`npm run build` 通过。
+  - 涉及**原生模块（.node）、新的文件类型入口、或需要 external 化的依赖**时，必须同步修改 `build.js` 并在对应位置扩展注释。
 - build.js 中的注释必须保留，不要删除。新增功能时，在原有注释结构基础上扩展。
 - `npm run build` — 生产构建（压缩、无 sourcemap）
 - `npm run build:watch` — 开发模式（不压缩、开启 sourcemap、文件变更自动 rebuild）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,5 +38,6 @@
   - `mcp__getDsl` — `{ dsl: { styles, nodes }, componentDocumentLinks, rules }`（节点在 `dsl.nodes`）
   - `mcp__getDesignSvgs` — `{ svgs: { key: value }, nodeCount }`，含空缓存 `{ message, svgs: {}, nodeCount: 0 }`
   - `mcp__getDesignTexts` — `{ texts: { key: value }, textCount }`，含空缓存
+  - `mcp__extractSvg` — `{ count, svgs: [{ name, id, svg }] }`（`svgs` 是**数组**，走 `svgListToTree`，区别于 getDesignSvgs 的对象 map）
   - `mcp__getMeta` — `{ result, rules }`（`rules` 是 markdown 字符串）：`tree` 下回退 JSON（不可把 markdown 塞进 tree 布局），`json`/`yaml` 正常
 - 验证清单：每种 shape 用 `--format=json|yaml|tree` 各跑一次，确认：① 输出符合该格式（不是 JSON 回退）；② 无损往返（yaml 可 `yaml.load` 还原，tree 的 SVG/text 值逐字节保留）；③ dispatch 能穿透 `dsl`/`nodes`/`sections`/`svgs`/`texts` 等 wrapper 键。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,12 @@
   - 工具描述（`*_TOOL_DESCRIPTION`）— 两个项目中对应的 tool 文件
 - 修改一处后，必须检查另一个项目的对应文件并同步变更。
 
+### 例外：`format` 功能为 client-only（不同步到 frontend-mcp-server）
+
+- `format` 参数（json/yaml/tree）、`--format` CLI flag、`DEFAULT_FORMAT` 环境变量、`src/utils/format.ts` 序列化器，以及 SERVER_INSTRUCTIONS 中的 `### Output Format` 小节，**都是 `mastergo-magic-mcp`（client）独有的**，刻意不同步到 `frontend-mcp-server`（server）。
+- 原因：format 是 client 端对其从 server HTTP 接口拿到的 JSON 做的**展示层转换**，server 的 DSL 生成逻辑（精度敏感）不涉及。两者是独立部署路径（client=stdio MCP，server=SSE MCP + HTTP 路由），client 的工具 schema 带 `format`、server 的不带，互不影响。
+- **同步 SERVER_INSTRUCTIONS / 工具描述时，注意不要把 client 独有的 `format` 相关内容（如 `### Output Format` 小节、`format` 参数描述）同步到 server。** 其他内容的 dual-sync 规则照旧。
+
 ## 文档同步（README 双语）
 
 - 本项目同时维护 `README.md`（英文）和 `README.zh-CN.md`（中文），两份文档内容必须保持一致，仅语言不同。
@@ -20,10 +26,11 @@
 
 - All imports must be placed at the top of the file. Do not use dynamic `import()` or write `import` statements in the middle of code.
 
-## Lint（每次改动必跑）
+## Lint & Test（每次改动必跑）
 
-- **每次代码改动后，必须执行 `npm run lint`，且 0 error 才算通过**（warning 不阻断，但应尽量消除）。`npm run lint:fix` 可自动修复可修复项（格式、简单规则）。
-- 提交/合并前必做清单：`npm run lint`（0 error）+ `npm run build`（构建通过）。CI（`.github/workflows/ci.yml`）已强制 lint → build，本地先跑可避免 CI 红。
+- **每次代码改动后，必须执行 `npm run lint`（0 error）+ `npm run test`（全过）**。`npm run lint:fix` 可自动修复可修复项（格式、简单规则）。
+- 提交/合并前必做清单：`npm run lint`（0 error）+ `npm run test`（全过）+ `npm run build`（构建通过）。CI（`.github/workflows/ci.yml`）已强制 lint → test → build，本地先跑可避免 CI 红。
+- 测试用 Node 内置 `node:test`（零额外依赖），测试源在 `test/`，经 esbuild 打包到 `.test/`（已 gitignore）。`format.ts` 的 6 种响应 shape × json/yaml/tree + 边界用例均在 `test/format.test.ts` 覆盖；改动 `format.ts` 或新增工具的响应 shape 时，必须同步补/改测试。
 - 规则定义在 `.eslintrc.json`：`eslint:recommended` + `plugin:@typescript-eslint/recommended`。已知约定：
   - `@typescript-eslint/no-explicit-any` 为 **warn**（本项目 catch 子句、API 边界大量使用 `any`，属有意为之；新增代码能具象化类型时尽量不用 `any`）。
   - `@typescript-eslint/no-unused-vars` 为 **error**（未使用变量是真实缺陷；故意忽略的参数/变量用 `_` 前缀）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,14 @@
 - build.js 中的注释必须保留，不要删除。新增功能时，在原有注释结构基础上扩展。
 - `npm run build` — 生产构建（压缩、无 sourcemap）
 - `npm run build:watch` — 开发模式（不压缩、开启 sourcemap、文件变更自动 rebuild）
+
+## 输出格式验证（format / 序列化）
+
+- **任何涉及 `format`（json/yaml/tree）或按 payload shape 分发的改动，必须用真实 server 响应验证所有 shape，不能只用构造样例。**（历史教训：构造的 `{nodes}` 样例通过测试，但真实响应把节点树嵌在 `dsl.nodes` / `sections` 下，导致 tree 静默回退 JSON。）
+- 必须覆盖的真实响应 shape（用真实 fileId/layerId，经 stdio 驱动 `dist/index.js`，或直连 `/mcp/*` 路由）：
+  - `mcp__getDesignSections` Mode 1 — section 列表：`{ sections, totalSections, rootMetadata, rootContainer, splitContainers }`
+  - `mcp__getDesignSections` Mode 2 — 单个 section：`{ sectionIndex, section, dsl: { styles, nodes }, ... }`（节点在 **`dsl.nodes`**）
+  - `mcp__getDsl` — `{ dsl: { styles, nodes }, componentDocumentLinks, rules }`（节点在 `dsl.nodes`）
+  - `mcp__getDesignSvgs` — `{ svgs: { key: value }, nodeCount }`，含空缓存 `{ message, svgs: {}, nodeCount: 0 }`
+  - `mcp__getDesignTexts` — `{ texts: { key: value }, textCount }`，含空缓存
+- 验证清单：每种 shape 用 `--format=json|yaml|tree` 各跑一次，确认：① 输出符合该格式（不是 JSON 回退）；② 无损往返（yaml 可 `yaml.load` 还原，tree 的 SVG/text 值逐字节保留）；③ dispatch 能穿透 `dsl`/`nodes`/`sections`/`svgs`/`texts` 等 wrapper 键。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,15 @@
 
 - All imports must be placed at the top of the file. Do not use dynamic `import()` or write `import` statements in the middle of code.
 
+## Lint（每次改动必跑）
+
+- **每次代码改动后，必须执行 `npm run lint`，且 0 error 才算通过**（warning 不阻断，但应尽量消除）。`npm run lint:fix` 可自动修复可修复项（格式、简单规则）。
+- 提交/合并前必做清单：`npm run lint`（0 error）+ `npm run build`（构建通过）。CI（`.github/workflows/ci.yml`）已强制 lint → build，本地先跑可避免 CI 红。
+- 规则定义在 `.eslintrc.json`：`eslint:recommended` + `plugin:@typescript-eslint/recommended`。已知约定：
+  - `@typescript-eslint/no-explicit-any` 为 **warn**（本项目 catch 子句、API 边界大量使用 `any`，属有意为之；新增代码能具象化类型时尽量不用 `any`）。
+  - `@typescript-eslint/no-unused-vars` 为 **error**（未使用变量是真实缺陷；故意忽略的参数/变量用 `_` 前缀）。
+- 新增/调整 lint 规则时：先 `npm run lint` 看全量影响，确认不会引入大量历史 error；若引入，要么修复代码、要么在该规则上加注释说明降级为 warn。
+
 ## Build
 
 - **新增功能或依赖时，必须检查 `build.js` 是否需要同步更新**。检查项：`external` 列表（仅排除 Node 内建模块，所有第三方依赖默认打包）、`loader`、`entryPoints`、`target`、`resolveExtensions`、`minify`/`sourcemap`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,4 +38,5 @@
   - `mcp__getDsl` — `{ dsl: { styles, nodes }, componentDocumentLinks, rules }`（节点在 `dsl.nodes`）
   - `mcp__getDesignSvgs` — `{ svgs: { key: value }, nodeCount }`，含空缓存 `{ message, svgs: {}, nodeCount: 0 }`
   - `mcp__getDesignTexts` — `{ texts: { key: value }, textCount }`，含空缓存
+  - `mcp__getMeta` — `{ result, rules }`（`rules` 是 markdown 字符串）：`tree` 下回退 JSON（不可把 markdown 塞进 tree 布局），`json`/`yaml` 正常
 - 验证清单：每种 shape 用 `--format=json|yaml|tree` 各跑一次，确认：① 输出符合该格式（不是 JSON 回退）；② 无损往返（yaml 可 `yaml.load` 还原，tree 的 SVG/text 值逐字节保留）；③ dispatch 能穿透 `dsl`/`nodes`/`sections`/`svgs`/`texts` 等 wrapper 键。

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Alternatively, you can use environment variables instead of command line argumen
 
 ### Tool Output Format
 
-The design-data tools (`mcp__getDesignSections`, `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, `mcp__getMeta`) accept an optional `format` parameter that controls how the payload is serialized. It defaults to `json`, or to the value set via `--format` / `DEFAULT_FORMAT` (see [Command Line Options](#command-line-options)).
+The design-data tools (`mcp__getDesignSections`, `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, `mcp__extractSvg`, `mcp__getMeta`) accept an optional `format` parameter that controls how the payload is serialized. It defaults to `json`, or to the value set via `--format` / `DEFAULT_FORMAT` (see [Command Line Options](#command-line-options)).
 
 | Value | Description |
 | --- | --- |
@@ -120,7 +120,7 @@ Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerI
 
 Notes:
 
-- `tree` applies to all five tools' responses: `mcp__getDesignSections` (section list and per-section DSL), `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, and `mcp__getMeta`. `mcp__getMeta` falls back to JSON under `tree` because its `rules` field is markdown (the tree layout would corrupt the markdown's headings/code blocks); other payloads render as tree. Truly unknown shapes also fall back to JSON — no data is ever mis-formatted.
+- `tree` applies to all six tools' responses: `mcp__getDesignSections` (section list and per-section DSL), `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, `mcp__extractSvg`, and `mcp__getMeta`. `mcp__getMeta` falls back to JSON under `tree` because its `rules` field is markdown (the tree layout would corrupt the markdown's headings/code blocks); other payloads render as tree. Truly unknown shapes also fall back to JSON — no data is ever mis-formatted.
 - For `mcp__getDesignTexts`, `json` is recommended for maximum verbatim-text fidelity — though all formats round-trip without data loss.
 - All formats round-trip without data loss. An invalid or omitted `format` value falls back to `json`.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Restore design, save as HTML file: https://{domain}/goto/{shortLink}
 ### Command Line Options
 
 ```
-npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--debug] [--no-rule]
+npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--debug] [--no-rule]
 ```
 
 #### Parameters:
@@ -82,13 +82,14 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 - `--url=API_URL` (optional): API base URL, defaults to http://localhost:3000
 - `--rule=RULE_NAME` (optional): Add design rules to apply, can be used multiple times
 - `--proxy=PROXY_URL` (optional): HTTP/HTTPS proxy URL (e.g., `http://127.0.0.1:7890`), also supports `HTTPS_PROXY` / `HTTP_PROXY` environment variables
+- `--format=FORMAT` (optional): Default output format for design-data tools — one of `json` (default), `yaml`, `tree`. An explicit per-call `format` tool parameter overrides this. Also settable via the `DEFAULT_FORMAT` environment variable.
 - `--debug` (optional): Enable debug mode for detailed error information
 - `--no-rule` (optional): Disable default rules
 
 You can also use space-separated format for parameters:
 
 ```
-npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --debug
+npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --format FORMAT --debug
 ```
 
 #### Environment Variables
@@ -98,7 +99,30 @@ Alternatively, you can use environment variables instead of command line argumen
 - `MG_MCP_TOKEN` or `MASTERGO_API_TOKEN`: MasterGo API token
 - `API_BASE_URL`: API base URL
 - `RULES`: JSON array of rules (e.g., `'["rule1", "rule2"]'`)
+- `DEFAULT_FORMAT`: Default output format for design-data tools (`json` | `yaml` | `tree`); the `--format` argument and an explicit per-call `format` tool parameter take precedence.
 - `HTTPS_PROXY` / `https_proxy` / `HTTP_PROXY` / `http_proxy`: HTTP(S) proxy URL (the `--proxy` argument takes priority)
+
+### Tool Output Format
+
+The design-data tools (`mcp__getDesignSections`, `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`) accept an optional `format` parameter that controls how the payload is serialized. It defaults to `json`, or to the value set via `--format` / `DEFAULT_FORMAT` (see [Command Line Options](#command-line-options)).
+
+| Value | Description |
+| --- | --- |
+| `json` | **Default.** Compact JSON — useful when piping output into tools that expect JSON. Byte-identical to the prior behavior. |
+| `yaml` | Fewer tokens than JSON for typical designs (flat layouts with repeated values benefit most). |
+| `tree` | Experimental compact format. Structural keys (`id`, `name`, `type`) are encoded positionally on each node line, and style values stay deduplicated in a `globalVars` block. Designs with heavy style reuse see the largest token savings. |
+
+The format is chosen per tool call by the AI model. To influence it, mention the desired format in your prompt, for example:
+
+```
+Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerId}
+```
+
+Notes:
+
+- Only DSL node-tree payloads (the full section DSL and `mcp__getDsl` output) use the compact `tree` layout; the section list, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, and other lightweight responses fall back to JSON so no data is ever mis-formatted.
+- For `mcp__getDesignTexts`, `json` is recommended for maximum verbatim-text fidelity — though all formats round-trip without data loss.
+- All formats round-trip without data loss. An invalid or omitted `format` value falls back to `json`.
 
 ### Installing via Smithery Marketplace
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerI
 
 Notes:
 
-- Only DSL node-tree payloads (the full section DSL and `mcp__getDsl` output) use the compact `tree` layout; the section list, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, and other lightweight responses fall back to JSON so no data is ever mis-formatted.
+- `tree` applies to all four tools' responses: `mcp__getDesignSections` (section list and per-section DSL), `mcp__getDsl` (full DSL), `mcp__getDesignSvgs`, and `mcp__getDesignTexts`. Truly unknown shapes fall back to JSON — no data is ever mis-formatted.
 - For `mcp__getDesignTexts`, `json` is recommended for maximum verbatim-text fidelity — though all formats round-trip without data loss.
 - All formats round-trip without data loss. An invalid or omitted `format` value falls back to `json`.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Alternatively, you can use environment variables instead of command line argumen
 
 ### Tool Output Format
 
-The design-data tools (`mcp__getDesignSections`, `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`) accept an optional `format` parameter that controls how the payload is serialized. It defaults to `json`, or to the value set via `--format` / `DEFAULT_FORMAT` (see [Command Line Options](#command-line-options)).
+The design-data tools (`mcp__getDesignSections`, `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, `mcp__getMeta`) accept an optional `format` parameter that controls how the payload is serialized. It defaults to `json`, or to the value set via `--format` / `DEFAULT_FORMAT` (see [Command Line Options](#command-line-options)).
 
 | Value | Description |
 | --- | --- |
@@ -120,7 +120,7 @@ Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerI
 
 Notes:
 
-- `tree` applies to all four tools' responses: `mcp__getDesignSections` (section list and per-section DSL), `mcp__getDsl` (full DSL), `mcp__getDesignSvgs`, and `mcp__getDesignTexts`. Truly unknown shapes fall back to JSON — no data is ever mis-formatted.
+- `tree` applies to all five tools' responses: `mcp__getDesignSections` (section list and per-section DSL), `mcp__getDsl`, `mcp__getDesignSvgs`, `mcp__getDesignTexts`, and `mcp__getMeta`. `mcp__getMeta` falls back to JSON under `tree` because its `rules` field is markdown (the tree layout would corrupt the markdown's headings/code blocks); other payloads render as tree. Truly unknown shapes also fall back to JSON — no data is ever mis-formatted.
 - For `mcp__getDesignTexts`, `json` is recommended for maximum verbatim-text fidelity — though all formats round-trip without data loss.
 - All formats round-trip without data loss. An invalid or omitted `format` value falls back to `json`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ MCP 服务连接成功后，可以在 AI 对话中使用以下提示词：
 ### 命令行选项
 
 ```
-npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--debug] [--no-rule]
+npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--debug] [--no-rule]
 ```
 
 #### 参数:
@@ -82,13 +82,14 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 - `--url=API_URL` (可选): API 基础 URL，默认为 http://localhost:3000
 - `--rule=RULE_NAME` (可选): 添加要应用的设计规则，可多次使用
 - `--proxy=PROXY_URL` (可选): HTTP/HTTPS 代理地址（如 `http://127.0.0.1:7890`），也支持 `HTTPS_PROXY` / `HTTP_PROXY` 环境变量
+- `--format=FORMAT` (可选): 设计数据工具的默认输出格式 —— 取值 `json`（默认）、`yaml`、`tree`。工具调用时显式传入的 `format` 参数优先级更高。也可通过 `DEFAULT_FORMAT` 环境变量设置。
 - `--debug` (可选): 启用调试模式，提供详细错误信息
 - `--no-rule` (可选): 禁用默认规则
 
 你也可以使用空格分隔的参数格式:
 
 ```
-npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --debug
+npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --format FORMAT --debug
 ```
 
 #### 环境变量
@@ -98,7 +99,30 @@ npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --prox
 - `MG_MCP_TOKEN` 或 `MASTERGO_API_TOKEN`: MasterGo API 令牌
 - `API_BASE_URL`: API 基础 URL
 - `RULES`: 规则的 JSON 数组 (例如: `'["rule1", "rule2"]'`)
+- `DEFAULT_FORMAT`: 设计数据工具的默认输出格式（`json` | `yaml` | `tree`）；`--format` 参数和工具调用时显式传入的 `format` 参数优先级更高。
 - `HTTPS_PROXY` / `https_proxy` / `HTTP_PROXY` / `http_proxy`: HTTP(S) 代理地址（`--proxy` 参数优先级更高）
+
+### 工具输出格式
+
+设计数据工具（`mcp__getDesignSections`、`mcp__getDsl`、`mcp__getDesignSvgs`、`mcp__getDesignTexts`）接受一个可选的 `format` 参数，用于控制数据的序列化方式。默认值为 `json`，或通过 `--format` / `DEFAULT_FORMAT` 设置的值（见[命令行选项](#命令行选项)）。
+
+| 取值 | 说明 |
+| --- | --- |
+| `json` | **默认。** 紧凑 JSON —— 适合将输出传递给期望 JSON 的工具。与历史行为逐字节一致。 |
+| `yaml` | 对于典型设计比 JSON 更省 token（扁平布局、重复值较多的设计收益最大）。 |
+| `tree` | 实验性紧凑格式。结构键（`id`、`name`、`type`）按位置编码在每个节点行上，样式值去重后保留在 `globalVars` 块中。样式复用较多的设计省 token 效果最明显。 |
+
+该格式由 AI 模型在每次工具调用时选择。如需影响其选择，可在提示词中指明所需格式，例如：
+
+```
+Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerId}
+```
+
+注意事项：
+
+- 只有 DSL 节点树数据（完整的 section DSL 和 `mcp__getDsl` 输出）使用紧凑的 `tree` 布局；section 列表、`mcp__getDesignSvgs`、`mcp__getDesignTexts` 及其他轻量响应回退为 JSON，以确保数据不会被错误格式化。
+- 对于 `mcp__getDesignTexts`，建议使用 `json` 以保证文本的逐字还原精度 —— 尽管所有格式均可无损往返。
+- 所有格式均可无损往返。无效或省略的 `format` 值会回退为 `json`。
 
 ### 通过 Smithery 市场安装
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,7 +120,7 @@ Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerI
 
 注意事项：
 
-- 只有 DSL 节点树数据（完整的 section DSL 和 `mcp__getDsl` 输出）使用紧凑的 `tree` 布局；section 列表、`mcp__getDesignSvgs`、`mcp__getDesignTexts` 及其他轻量响应回退为 JSON，以确保数据不会被错误格式化。
+- `tree` 适用于全部四个工具的响应：`mcp__getDesignSections`（section 列表与单个 section DSL）、`mcp__getDsl`（完整 DSL）、`mcp__getDesignSvgs`、`mcp__getDesignTexts`。只有真正未知的 shape 才回退为 JSON —— 数据不会被错误格式化。
 - 对于 `mcp__getDesignTexts`，建议使用 `json` 以保证文本的逐字还原精度 —— 尽管所有格式均可无损往返。
 - 所有格式均可无损往返。无效或省略的 `format` 值会回退为 `json`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,7 +104,7 @@ npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --prox
 
 ### 工具输出格式
 
-设计数据工具（`mcp__getDesignSections`、`mcp__getDsl`、`mcp__getDesignSvgs`、`mcp__getDesignTexts`）接受一个可选的 `format` 参数，用于控制数据的序列化方式。默认值为 `json`，或通过 `--format` / `DEFAULT_FORMAT` 设置的值（见[命令行选项](#命令行选项)）。
+设计数据工具（`mcp__getDesignSections`、`mcp__getDsl`、`mcp__getDesignSvgs`、`mcp__getDesignTexts`、`mcp__getMeta`）接受一个可选的 `format` 参数，用于控制数据的序列化方式。默认值为 `json`，或通过 `--format` / `DEFAULT_FORMAT` 设置的值（见[命令行选项](#命令行选项)）。
 
 | 取值 | 说明 |
 | --- | --- |
@@ -120,7 +120,7 @@ Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerI
 
 注意事项：
 
-- `tree` 适用于全部四个工具的响应：`mcp__getDesignSections`（section 列表与单个 section DSL）、`mcp__getDsl`（完整 DSL）、`mcp__getDesignSvgs`、`mcp__getDesignTexts`。只有真正未知的 shape 才回退为 JSON —— 数据不会被错误格式化。
+- `tree` 适用于全部五个工具的响应：`mcp__getDesignSections`（section 列表与单个 section DSL）、`mcp__getDsl`（完整 DSL）、`mcp__getDesignSvgs`、`mcp__getDesignTexts`、`mcp__getMeta`。其中 `mcp__getMeta` 在 `tree` 下回退为 JSON —— 它的 `rules` 字段是 markdown，强行套用 tree 布局会破坏 markdown 的标题/代码块；其余 payload 正常渲染为 tree。只有真正未知的 shape 才回退为 JSON —— 数据不会被错误格式化。
 - 对于 `mcp__getDesignTexts`，建议使用 `json` 以保证文本的逐字还原精度 —— 尽管所有格式均可无损往返。
 - 所有格式均可无损往返。无效或省略的 `format` 值会回退为 `json`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,7 +104,7 @@ npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --prox
 
 ### 工具输出格式
 
-设计数据工具（`mcp__getDesignSections`、`mcp__getDsl`、`mcp__getDesignSvgs`、`mcp__getDesignTexts`、`mcp__getMeta`）接受一个可选的 `format` 参数，用于控制数据的序列化方式。默认值为 `json`，或通过 `--format` / `DEFAULT_FORMAT` 设置的值（见[命令行选项](#命令行选项)）。
+设计数据工具（`mcp__getDesignSections`、`mcp__getDsl`、`mcp__getDesignSvgs`、`mcp__getDesignTexts`、`mcp__extractSvg`、`mcp__getMeta`）接受一个可选的 `format` 参数，用于控制数据的序列化方式。默认值为 `json`，或通过 `--format` / `DEFAULT_FORMAT` 设置的值（见[命令行选项](#命令行选项)）。
 
 | 取值 | 说明 |
 | --- | --- |
@@ -120,7 +120,7 @@ Restore design, use tree format: https://{domain}/file/{fileId}?layer_id={layerI
 
 注意事项：
 
-- `tree` 适用于全部五个工具的响应：`mcp__getDesignSections`（section 列表与单个 section DSL）、`mcp__getDsl`（完整 DSL）、`mcp__getDesignSvgs`、`mcp__getDesignTexts`、`mcp__getMeta`。其中 `mcp__getMeta` 在 `tree` 下回退为 JSON —— 它的 `rules` 字段是 markdown，强行套用 tree 布局会破坏 markdown 的标题/代码块；其余 payload 正常渲染为 tree。只有真正未知的 shape 才回退为 JSON —— 数据不会被错误格式化。
+- `tree` 适用于全部六个工具的响应：`mcp__getDesignSections`（section 列表与单个 section DSL）、`mcp__getDsl`（完整 DSL）、`mcp__getDesignSvgs`、`mcp__getDesignTexts`、`mcp__extractSvg`、`mcp__getMeta`。其中 `mcp__getMeta` 在 `tree` 下回退为 JSON —— 它的 `rules` 字段是 markdown，强行套用 tree 布局会破坏 markdown 的标题/代码块；其余 payload 正常渲染为 tree。只有真正未知的 shape 才回退为 JSON —— 数据不会被错误格式化。
 - 对于 `mcp__getDesignTexts`，建议使用 `json` 以保证文本的逐字还原精度 —— 尽管所有格式均可无损往返。
 - 所有格式均可无损往返。无效或省略的 `format` 值会回退为 `json`。
 

--- a/build.js
+++ b/build.js
@@ -140,7 +140,7 @@ async function build() {
       console.log("");
       console.log("🔧 Or you can test locally using the following command:");
       console.log(
-        "   node dist/index.js --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--no-rule] [--debug]"
+        "   node dist/index.js --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--format=FORMAT] [--no-rule] [--debug]"
       );
     }
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
     "@modelcontextprotocol/sdk": "^1.6.1",
     "axios": "1.6.0",
     "https-proxy-agent": "^9.0.0",
+    "js-yaml": "^4.1.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.8.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "scripts": {
     "build": "node build.js",
     "build:watch": "node build.js --watch",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
     "start": "node dist/index.js --token=test --url=http://localhost:3000 --debug",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:watch": "node build.js --watch",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
+    "test": "esbuild test/format.test.ts --bundle --platform=node --format=cjs --outfile=.test/format.test.cjs && node --test .test/format.test.cjs",
     "start": "node dist/index.js --token=test --url=http://localhost:3000 --debug",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { GetDesignSvgsTool } from "./tools/get-design-svgs";
 import { GetDesignTextsTool } from "./tools/get-design-texts";
 import { ExtractSvgTool } from "./tools/extract-svg";
 import { parserArgs } from "./utils/args";
+import { normalizeFormat } from "./utils/format";
 
 const SERVER_INSTRUCTIONS = `
 ## MasterGo Design DSL - Section-by-Section Workflow
@@ -79,7 +80,20 @@ After ALL N sections have been fetched and SVG data retrieved:
 
 function main() {
   // Parse command line arguments and set environment variables
-  const { token, baseUrl, rules, debug, noRule, proxy } = parserArgs();
+  const { token, baseUrl, rules, debug, noRule, proxy, format } = parserArgs();
+
+  // `--format` (json|yaml|tree) sets the default output format for design-data tools.
+  // An explicit per-call `format` tool parameter still takes precedence (see utils/format.ts).
+  if (format) {
+    const normalized = normalizeFormat(format);
+    if (normalized) {
+      process.env.DEFAULT_FORMAT = normalized;
+    } else {
+      console.warn(
+        `Invalid --format value: "${format}". Must be one of: json, yaml, tree. Falling back to json.`
+      );
+    }
+  }
 
   if (debug) {
     process.env.DEBUG = "true";
@@ -89,6 +103,7 @@ function main() {
     console.log(`Rules: ${rules.length > 0 ? rules.join(", ") : "none"}`);
     console.log(`No Rule: ${noRule ? "enabled" : "disabled"}`);
     console.log(`Proxy: ${proxy || "none"}`);
+    console.log(`Format: ${process.env.DEFAULT_FORMAT || "json (default)"}`);
     console.log(`Debug mode: enabled`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,9 @@ After ALL N sections have been fetched and SVG data retrieved:
 - NEVER call both \`getDesignSections\` AND \`getDsl\` / \`extractSvg\` for the same design.
 - The section workflow provides COMPLETE data. Do NOT call \`getDsl\` to "verify".
 
+### Output Format:
+- The design-data tools (\`getDesignSections\`, \`getDsl\`, \`getDesignSvgs\`, \`getDesignTexts\`, \`extractSvg\`, \`getMeta\`) accept an optional \`format\` parameter: \`json\` (default), \`yaml\`, or \`tree\`. \`yaml\`/\`tree\` use fewer tokens for large designs; all three round-trip without data loss. Set a session-wide default with the \`--format\` CLI flag or \`DEFAULT_FORMAT\` env var.
+
 ### Text Fidelity Rules:
 - TEXT nodes contain actual text in node.text array. Read EACH node's text and use it EXACTLY.
 - Do NOT duplicate text from one node to another — each TEXT node has unique content.

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,9 @@ function main() {
 
   // `--format` (json|yaml|tree) sets the default output format for design-data tools.
   // An explicit per-call `format` tool parameter still takes precedence (see utils/format.ts).
-  if (format) {
+  // `format` is `undefined` only when the flag is absent; any explicit-but-invalid value
+  // (including `--format=`) is warned about and falls back to json.
+  if (format !== undefined) {
     const normalized = normalizeFormat(format);
     if (normalized) {
       process.env.DEFAULT_FORMAT = normalized;

--- a/src/tools/extract-svg.ts
+++ b/src/tools/extract-svg.ts
@@ -9,7 +9,7 @@ Extract SVG data from MasterGo design files. This tool retrieves the DSL from a 
 You can provide either:
 1. fileId and layerId directly, or
 2. a short link (like https://{domain}/goto/LhGgBAK)
-Returns an array of SVG strings, one per icon/instance found in the design.
+Returns { count, svgs: [{ name, id, svg }] } — one entry per icon/instance found in the design.
 `;
 
 export class ExtractSvgTool extends BaseTool {

--- a/src/tools/extract-svg.ts
+++ b/src/tools/extract-svg.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
 
 const EXTRACT_SVG_TOOL_NAME = "mcp__extractSvg";
 const EXTRACT_SVG_TOOL_DESCRIPTION = `
@@ -42,11 +43,12 @@ export class ExtractSvgTool extends BaseTool {
       .describe(
         "Solid background color for the SVG (e.g. '#000000', 'black'). Useful for previewing white/light icons."
       ),
+    format: formatField(),
   });
 
   async execute(params: z.infer<typeof this.schema>) {
     try {
-      const { fileId, layerId, shortLink, backgroundColor } = params;
+      const { fileId, layerId, shortLink, backgroundColor, format } = params;
 
       if (!shortLink && (!fileId || !layerId)) {
         throw new Error(
@@ -77,7 +79,7 @@ export class ExtractSvgTool extends BaseTool {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result),
+            text: formatOutput(result, format),
           },
         ],
       };

--- a/src/tools/get-design-sections.ts
+++ b/src/tools/get-design-sections.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
 
 const DESIGN_SECTIONS_TOOL_NAME = "mcp__getDesignSections";
 const DESIGN_SECTIONS_TOOL_DESCRIPTION = `
@@ -69,9 +70,10 @@ export class GetDesignSectionsTool extends BaseTool {
       .describe(
         "0-based section index. If omitted, returns the section list only. If provided, returns full DSL for that specific section."
       ),
+    format: formatField(),
   });
 
-  async execute({ fileId, layerId, shortLink, sourceLayerId, sectionIndex }: z.infer<typeof this.schema>) {
+  async execute({ fileId, layerId, shortLink, sourceLayerId, sectionIndex, format }: z.infer<typeof this.schema>) {
     try {
       if (!shortLink && (!fileId || !layerId)) {
         throw new Error(
@@ -106,7 +108,7 @@ export class GetDesignSectionsTool extends BaseTool {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result),
+            text: formatOutput(result, format),
           },
         ],
       };

--- a/src/tools/get-design-svgs.ts
+++ b/src/tools/get-design-svgs.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
 
 const DESIGN_SVGS_TOOL_NAME = "mcp__getDesignSvgs";
 const DESIGN_SVGS_TOOL_DESCRIPTION = `
@@ -44,6 +45,7 @@ export class GetDesignSvgsTool extends BaseTool {
       .string()
       .optional()
       .describe("Short link (like https://{domain}/goto/LhGgBAK)."),
+    format: formatField(),
   });
 
   async execute({
@@ -51,6 +53,7 @@ export class GetDesignSvgsTool extends BaseTool {
     layerId,
     sourceLayerId,
     shortLink,
+    format,
   }: z.infer<typeof this.schema>) {
     try {
       if (!shortLink && (!fileId || !layerId)) {
@@ -85,7 +88,7 @@ export class GetDesignSvgsTool extends BaseTool {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result),
+            text: formatOutput(result, format),
           },
         ],
       };

--- a/src/tools/get-design-texts.ts
+++ b/src/tools/get-design-texts.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
 
 const DESIGN_TEXTS_TOOL_NAME = "mcp__getDesignTexts";
 const DESIGN_TEXTS_TOOL_DESCRIPTION = `
@@ -44,6 +45,7 @@ export class GetDesignTextsTool extends BaseTool {
       .string()
       .optional()
       .describe("Short link (like https://{domain}/goto/LhGgBAK)."),
+    format: formatField(),
   });
 
   async execute({
@@ -51,6 +53,7 @@ export class GetDesignTextsTool extends BaseTool {
     layerId,
     sourceLayerId,
     shortLink,
+    format,
   }: z.infer<typeof this.schema>) {
     try {
       if (!shortLink && (!fileId || !layerId)) {
@@ -85,7 +88,7 @@ export class GetDesignTextsTool extends BaseTool {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result),
+            text: formatOutput(result, format),
           },
         ],
       };

--- a/src/tools/get-dsl.ts
+++ b/src/tools/get-dsl.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
 
 const DSL_TOOL_NAME = "mcp__getDsl";
 const DSL_TOOL_DESCRIPTION = `
@@ -46,9 +47,10 @@ export class GetDslTool extends BaseTool {
       .string()
       .optional()
       .describe("Short link (like https://{domain}/goto/LhGgBAK)."),
+    format: formatField(),
   });
 
-  async execute({ fileId, layerId, sourceLayerId, shortLink }: z.infer<typeof this.schema>) {
+  async execute({ fileId, layerId, sourceLayerId, shortLink, format }: z.infer<typeof this.schema>) {
     try {
       if (!shortLink && (!fileId || !layerId)) {
         throw new Error(
@@ -78,7 +80,7 @@ export class GetDslTool extends BaseTool {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(dsl),
+            text: formatOutput(dsl, format),
           },
         ],
       };

--- a/src/tools/get-dsl.ts
+++ b/src/tools/get-dsl.ts
@@ -11,7 +11,7 @@ Prefer mcp__getDesignSections as the primary tool for all designs.
 You can provide either:
 1. fileId and layerId directly, or
 2. a short link (like https://{domain}/goto/LhGgBAK)
-This tool returns the raw DSL data in JSON format that you can then parse and analyze.
+This tool returns the raw DSL data that you can then parse and analyze. Use the optional 'format' parameter (json/yaml/tree, defaults to json) to control the serialization.
 This tool also returns the rules you must follow when generating code.
 The DSL data can also be used to transform and generate code for different frameworks.
 `;

--- a/src/tools/get-meta.ts
+++ b/src/tools/get-meta.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
 import rules from "../markdown/meta.md";
 
 const META_TOOL_NAME = "mcp__getMeta";
@@ -36,19 +37,17 @@ export class GetMetaTool extends BaseTool {
       .describe(
         "Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries."
       ),
+    format: formatField(),
   });
 
-  async execute({ fileId, layerId, sourceLayerId }: z.infer<typeof this.schema>) {
+  async execute({ fileId, layerId, sourceLayerId, format }: z.infer<typeof this.schema>) {
     try {
       const result = await httpUtilInstance.getMeta(fileId, layerId, sourceLayerId);
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({
-              result,
-              rules,
-            }),
+            text: formatOutput({ result, rules }, format),
           },
         ],
       };

--- a/src/tools/get-version.ts
+++ b/src/tools/get-version.ts
@@ -15,7 +15,7 @@ export class GetVersionTool extends BaseTool {
 
   schema = z.object({});
 
-  async execute({}: z.infer<typeof this.schema>) {
+  async execute() {
     return {
       content: [
         {

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -92,6 +92,23 @@ function parseProxy(): string {
   return proxy;
 }
 
+function parseFormat(): string {
+  const args = getArgs();
+  let format = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--format" && i + 1 < args.length) {
+      format = args[i + 1];
+      break;
+    } else if (args[i].startsWith("--format=")) {
+      format = args[i].split("=")[1];
+      break;
+    }
+  }
+
+  return format;
+}
+
 export function parserArgs(): {
   token: string;
   baseUrl: string;
@@ -99,6 +116,7 @@ export function parserArgs(): {
   debug: boolean;
   noRule: boolean;
   proxy: string;
+  format: string;
 } {
   const token = parseToken();
   const baseUrl = parseUrl();
@@ -106,6 +124,7 @@ export function parserArgs(): {
   const debug = parseDebug();
   const noRule = parseNoRule();
   const proxy = parseProxy();
+  const format = parseFormat();
 
   return {
     token,
@@ -114,7 +133,8 @@ export function parserArgs(): {
     debug,
     noRule,
     proxy,
+    format,
   };
 }
 
-export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseProxy, getArgs };
+export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseProxy, parseFormat, getArgs };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -92,21 +92,21 @@ function parseProxy(): string {
   return proxy;
 }
 
-function parseFormat(): string {
+// Returns the raw --format value, or `undefined` when the flag is absent.
+// An explicit empty value (`--format=`) is returned as "" so the caller can warn
+// rather than silently falling back.
+function parseFormat(): string | undefined {
   const args = getArgs();
-  let format = "";
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--format" && i + 1 < args.length) {
-      format = args[i + 1];
-      break;
+      return args[i + 1];
     } else if (args[i].startsWith("--format=")) {
-      format = args[i].split("=")[1];
-      break;
+      return args[i].split("=")[1];
     }
   }
 
-  return format;
+  return undefined;
 }
 
 export function parserArgs(): {
@@ -116,7 +116,7 @@ export function parserArgs(): {
   debug: boolean;
   noRule: boolean;
   proxy: string;
-  format: string;
+  format: string | undefined;
 } {
   const token = parseToken();
   const baseUrl = parseUrl();

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,259 @@
+import { z } from "zod";
+import yaml from "js-yaml";
+
+/**
+ * Output-format support for design-data tools.
+ *
+ * The `format` parameter lets the caller trade readability for token cost on the
+ * (often very large) DSL payloads. `json` is the default and matches the prior
+ * behavior exactly; `yaml` and `tree` are opt-in compact representations.
+ *
+ * IMPORTANT (fidelity-first): every non-JSON format must round-trip without data
+ * loss. The `tree` renderer therefore renders *all* node properties (known keys
+ * inline + a generic pass-through for the rest) so nothing is silently dropped,
+ * and any serialization failure falls back to JSON rather than emitting partial
+ * output.
+ */
+
+export const FORMAT_VALUES = ["json", "yaml", "tree"] as const;
+export type OutputFormat = (typeof FORMAT_VALUES)[number];
+
+export const FORMAT_DESCRIPTION = `Output format for design data. Defaults to json.
+- json — default; useful when piping output into tools that expect JSON.
+- yaml — fewer tokens than JSON for typical designs.
+- tree — experimental compact format. Structural keys (id, name, type) are encoded positionally on each node line, and style values stay deduplicated in a globalVars block. Designs with heavy style reuse see the largest token savings.`;
+
+/**
+ * Reusable zod field for the `format` tool parameter.
+ * Optional on the wire; the effective default (`json`) is applied in `formatOutput`.
+ */
+export function formatField() {
+  return z.enum(FORMAT_VALUES).optional().describe(FORMAT_DESCRIPTION);
+}
+
+/**
+ * Serialize design data in the requested format.
+ *
+ * Resolution order: explicit tool param  >  CLI/env default
+ * (`process.env.DEFAULT_FORMAT`, set from `--format` in index.ts)  >  `json`.
+ *
+ * Non-DSL payloads (section lists, meta, svgs, error objects) always fall back to
+ * JSON — the `tree` layout only applies to objects carrying a `nodes` array, so it
+ * never corrupts data it does not understand.
+ */
+export function formatOutput(
+  data: unknown,
+  format?: OutputFormat | string
+): string {
+  const fmt = resolveFormat(format);
+  if (fmt === "yaml") return toYaml(data);
+  if (fmt === "tree") return toTree(data);
+  return JSON.stringify(data); // json (default) — compact, identical to prior behavior
+}
+
+/**
+ * Validate a raw format string (from a tool param, CLI flag, or env var).
+ * Returns the normalized format, or null if invalid/unset.
+ */
+export function normalizeFormat(v?: string | null): OutputFormat | null {
+  return isOutputFormat(v) ? v : null;
+}
+
+/** Explicit format > CLI/env default > json. */
+function resolveFormat(format?: string | null): OutputFormat {
+  return (
+    normalizeFormat(format) ??
+    normalizeFormat(process.env.DEFAULT_FORMAT) ??
+    "json"
+  );
+}
+
+function isOutputFormat(v: unknown): v is OutputFormat {
+  return typeof v === "string" && (FORMAT_VALUES as readonly string[]).includes(v);
+}
+
+// ---------------------------------------------------------------------------
+// yaml
+// ---------------------------------------------------------------------------
+
+function toYaml(data: unknown): string {
+  try {
+    return yaml.dump(data, {
+      lineWidth: -1, // do not wrap long strings / path data
+      noRefs: true, // no &anchor / *alias — keeps output self-contained for the LLM
+      quotingType: '"',
+      sortKeys: false,
+    });
+  } catch {
+    // Never lose data: fall back to JSON (with a marker) if YAML serialization fails.
+    return "# yaml serialization failed; falling back to json\n" + JSON.stringify(data);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tree (experimental compact DSL format)
+// ---------------------------------------------------------------------------
+//
+// Layout:
+//   globalVars:            <- the server already-deduplicated `styles` map, verbatim
+//     <styleId>: <json>
+//   components: <json>      <- if present
+//   <otherTopLevelKey>: <json>
+//   tree:
+//   <TYPE> <id> "<name>" <w>x<h> @<rx>,<ry> fill=<id> stroke=<id>/<w> ...
+//     prop <k>=<v>          <- componentInfo.properties
+//     flex <json>           <- flexContainerInfo
+//     text "<content>" font=<id>
+//     textColor <json>
+//     <otherKey>=<json>     <- generic pass-through (fidelity safety net)
+//     <child ...>           <- children, indented one level deeper
+
+interface DslNode {
+  [key: string]: unknown;
+}
+interface DslPayload {
+  styles?: Record<string, unknown>;
+  nodes?: DslNode[];
+  components?: unknown;
+  [key: string]: unknown;
+}
+
+/** Node keys rendered specially; all others pass through generically. */
+const RESERVED_NODE_KEYS = new Set([
+  "type",
+  "id",
+  "name",
+  "layoutStyle",
+  "fill",
+  "strokeColor",
+  "strokeType",
+  "strokeAlign",
+  "strokeWidth",
+  "componentId",
+  "componentInfo",
+  "flexContainerInfo",
+  "text",
+  "textColor",
+  "children",
+]);
+
+function isDslPayload(data: unknown): data is DslPayload {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    !Array.isArray(data) &&
+    Array.isArray((data as DslPayload).nodes)
+  );
+}
+
+function toTree(data: unknown): string {
+  if (!isDslPayload(data)) {
+    // Only DSL node-trees get the compact layout; everything else stays JSON.
+    return JSON.stringify(data);
+  }
+  const dsl = data;
+  const lines: string[] = [];
+
+  // globalVars: the styles map is already deduplicated by the server; surface it verbatim.
+  lines.push("globalVars:");
+  if (dsl.styles && typeof dsl.styles === "object") {
+    for (const [key, val] of Object.entries(dsl.styles)) {
+      lines.push(`  ${key}: ${JSON.stringify(val)}`);
+    }
+  }
+
+  if (dsl.components !== undefined) {
+    lines.push(`components: ${JSON.stringify(dsl.components)}`);
+  }
+
+  // Other top-level keys (e.g. componentDocumentLinks, rules, sectionIndex) pass through.
+  for (const [key, val] of Object.entries(dsl)) {
+    if (key === "styles" || key === "nodes" || key === "components") continue;
+    lines.push(`${key}: ${JSON.stringify(val)}`);
+  }
+
+  lines.push("tree:");
+  for (const node of dsl.nodes ?? []) {
+    renderNode(node, 1, lines);
+  }
+  return lines.join("\n");
+}
+
+function renderNode(node: DslNode, depth: number, lines: string[]): void {
+  const pad = "  ".repeat(depth);
+  const ls = (node.layoutStyle as Record<string, unknown> | undefined) ?? {};
+  const dim = `${fmtNum(ls.width)}x${fmtNum(ls.height)}`;
+  const pos = `@${fmtNum(ls.relativeX)},${fmtNum(ls.relativeY)}`;
+
+  const extras: string[] = [];
+  pushIf(extras, "fill", node.fill);
+  if (node.strokeColor) {
+    extras.push(
+      `stroke=${node.strokeColor}${node.strokeWidth ? "/" + node.strokeWidth : ""}`
+    );
+  }
+  pushIf(extras, "strokeType", node.strokeType);
+  pushIf(extras, "strokeAlign", node.strokeAlign);
+  pushIf(extras, "component", node.componentId);
+
+  lines.push(
+    `${pad}${node.type ?? "?"} ${node.id ?? "?"} ${quote(node.name)} ${dim} ${pos}` +
+      (extras.length ? " " + extras.join(" ") : "")
+  );
+
+  const props = (node.componentInfo as { properties?: Record<string, unknown> } | undefined)
+    ?.properties;
+  if (props && typeof props === "object") {
+    for (const [k, v] of Object.entries(props)) {
+      lines.push(`${pad}  prop ${k}=${JSON.stringify(v)}`);
+    }
+  }
+
+  if (node.flexContainerInfo !== undefined) {
+    lines.push(`${pad}  flex ${JSON.stringify(node.flexContainerInfo)}`);
+  }
+
+  if (Array.isArray(node.text)) {
+    for (const t of node.text as Array<Record<string, unknown>>) {
+      const raw = t?.text;
+      const content =
+        typeof raw === "string" ? raw : JSON.stringify(raw);
+      lines.push(`${pad}  text ${quote(content)}${t?.font ? ` font=${t.font}` : ""}`);
+    }
+  }
+
+  if (node.textColor !== undefined) {
+    lines.push(`${pad}  textColor ${JSON.stringify(node.textColor)}`);
+  }
+
+  // Fidelity safety net: render any non-reserved property so no data is silently dropped.
+  for (const [key, val] of Object.entries(node)) {
+    if (RESERVED_NODE_KEYS.has(key) || val === undefined) continue;
+    lines.push(`${pad}  ${key}=${JSON.stringify(val)}`);
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children as DslNode[]) {
+      renderNode(child, depth + 1, lines);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// small helpers
+// ---------------------------------------------------------------------------
+
+function pushIf(arr: string[], label: string, val: unknown): void {
+  if (val !== undefined && val !== null && val !== "") {
+    arr.push(`${label}=${val}`);
+  }
+}
+
+function fmtNum(v: unknown): string {
+  return v === undefined || v === null ? "?" : String(v);
+}
+
+function quote(v: unknown): string {
+  const s = v === undefined || v === null ? "" : String(v);
+  return '"' + s.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -137,26 +137,49 @@ const RESERVED_NODE_KEYS = new Set([
   "children",
 ]);
 
-function isDslPayload(data: unknown): data is DslPayload {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    !Array.isArray(data) &&
-    Array.isArray((data as DslPayload).nodes)
-  );
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+/**
+ * Dispatch on the real response shapes returned by the server:
+ *   - Mode 2 section DSL: { sectionIndex, section, dsl: { styles, nodes, ... }, ... }
+ *   - getDsl:              { dsl: { styles, nodes, ... }, componentDocumentLinks, rules }
+ *   - Raw DSL:             { styles, nodes, components?, ... }
+ *   - Mode 1 section list: { sections, totalSections, rootMetadata, ... }
+ *   - getDesignSvgs/Texts: { svgs|texts: { key: value }, nodeCount|textCount }
+ * Primitives, arrays, and truly unknown objects fall back to JSON so data is never
+ * mis-formatted.
+ */
 function toTree(data: unknown): string {
-  if (!isDslPayload(data)) {
-    // Only DSL node-trees get the compact layout; everything else stays JSON.
+  if (!isPlainObject(data)) {
     return JSON.stringify(data);
   }
-  const dsl = data;
-  const lines: string[] = [];
+  const obj = data;
+  if (isPlainObject(obj.dsl) && Array.isArray((obj.dsl as DslPayload).nodes)) {
+    return wrappedDslToTree(obj);
+  }
+  if (Array.isArray(obj.nodes)) {
+    return renderDslBody(obj as DslPayload, []).join("\n");
+  }
+  if (Array.isArray(obj.sections)) {
+    return sectionListToTree(obj);
+  }
+  if (isPlainObject(obj.svgs) || isPlainObject(obj.texts)) {
+    return kvMapToTree(obj);
+  }
+  return JSON.stringify(data);
+}
 
+/**
+ * Render a raw DSL object ({ styles, nodes, components? }) as globalVars + tree.
+ * Other top-level keys pass through verbatim (fidelity safety net).
+ * Appends to (and returns) `lines` so callers can prepend wrapper metadata.
+ */
+function renderDslBody(dsl: DslPayload, lines: string[]): string[] {
   // globalVars: the styles map is already deduplicated by the server; surface it verbatim.
   lines.push("globalVars:");
-  if (dsl.styles && typeof dsl.styles === "object") {
+  if (isPlainObject(dsl.styles)) {
     for (const [key, val] of Object.entries(dsl.styles)) {
       lines.push(`  ${key}: ${JSON.stringify(val)}`);
     }
@@ -166,7 +189,7 @@ function toTree(data: unknown): string {
     lines.push(`components: ${JSON.stringify(dsl.components)}`);
   }
 
-  // Other top-level keys (e.g. componentDocumentLinks, rules, sectionIndex) pass through.
+  // Other top-level keys (e.g. componentDocumentLinks, rules) pass through.
   for (const [key, val] of Object.entries(dsl)) {
     if (key === "styles" || key === "nodes" || key === "components") continue;
     lines.push(`${key}: ${JSON.stringify(val)}`);
@@ -176,7 +199,101 @@ function toTree(data: unknown): string {
   for (const node of dsl.nodes ?? []) {
     renderNode(node, 1, lines);
   }
+  return lines;
+}
+
+/** Wrapped DSL (Mode 2 section DSL or getDsl): emit sibling metadata, then the nested `dsl` body. */
+function wrappedDslToTree(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === "dsl") continue; // rendered as body below
+    lines.push(`${key}: ${JSON.stringify(val)}`);
+  }
+  renderDslBody(obj.dsl as DslPayload, lines);
   return lines.join("\n");
+}
+
+const SECTION_ENTRY_KEYS = new Set([
+  "type", "id", "name", "nodeCount", "x", "y", "width", "height", "layoutStyle",
+]);
+
+/** Mode 1: emit list metadata, then a compact `sections:` block (lossless pass-through). */
+function sectionListToTree(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+  const sections = Array.isArray(obj.sections) ? (obj.sections as DslNode[]) : [];
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === "sections") continue;
+    lines.push(`${key}: ${JSON.stringify(val)}`);
+  }
+  lines.push("sections:");
+  sections.forEach((s, i) => {
+    const ls = (s.layoutStyle as Record<string, unknown> | undefined) ?? {};
+    const w = s.width ?? ls.width;
+    const h = s.height ?? ls.height;
+    const x = s.x ?? ls.relativeX;
+    const y = s.y ?? ls.relativeY;
+    const extras: string[] = [];
+    pushIf(extras, "nodeCount", s.nodeCount);
+    lines.push(
+      `  [${i}] ${s.type ?? "?"} ${s.id ?? "?"} ${quote(s.name)} ` +
+        `${fmtNum(w)}x${fmtNum(h)} @${fmtNum(x)},${fmtNum(y)}` +
+        (extras.length ? " " + extras.join(" ") : "")
+    );
+    // Fidelity safety net: any other section field.
+    for (const [k, v] of Object.entries(s)) {
+      if (SECTION_ENTRY_KEYS.has(k) || v === undefined) continue;
+      lines.push(`    ${k}=${JSON.stringify(v)}`);
+    }
+  });
+  return lines.join("\n");
+}
+
+/**
+ * Flat key→value map payloads: getDesignSvgs `{ svgs, nodeCount }` and
+ * getDesignTexts `{ texts, textCount }` (including the empty-cache variants).
+ * Sibling scalars pass through; the map renders as a `svgs:`/`texts:` block with
+ * one entry per line. Single-line values stay inline; multi-line values (SVG with
+ * newlines, long text) indent on the following line(s) — value bytes are emitted
+ * verbatim, never escaped, so SVG/text fidelity is preserved exactly.
+ */
+function kvMapToTree(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+  const mapKey = isPlainObject(obj.svgs) ? "svgs" : isPlainObject(obj.texts) ? "texts" : null;
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === mapKey) continue;
+    lines.push(`${key}: ${JSON.stringify(val)}`);
+  }
+  if (mapKey) {
+    lines.push(`${mapKey}:`);
+    const map = obj[mapKey] as Record<string, unknown>;
+    for (const [k, v] of Object.entries(map)) {
+      renderKvEntry(k, v, "  ", lines);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Render one map entry. Single-line string values go inline (`key: value`);
+ * anything else puts the key on its own line and the value indented beneath, so
+ * multi-line SVG / text content is preserved without escaping.
+ */
+function renderKvEntry(key: string, v: unknown, pad: string, lines: string[]): void {
+  if (typeof v === "string" && !v.includes("\n")) {
+    lines.push(`${pad}${key}: ${v}`);
+    return;
+  }
+  lines.push(`${pad}${key}:`);
+  const vpad = pad + "  ";
+  if (typeof v === "string") {
+    if (v === "") {
+      lines.push(`${vpad}""`);
+    } else {
+      for (const ln of v.split("\n")) lines.push(vpad + ln);
+    }
+  } else {
+    lines.push(`${vpad}${JSON.stringify(v)}`);
+  }
 }
 
 function renderNode(node: DslNode, depth: number, lines: string[]): void {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -84,9 +84,13 @@ function toYaml(data: unknown): string {
       quotingType: '"',
       sortKeys: false,
     });
-  } catch {
-    // Never lose data: fall back to JSON (with a marker) if YAML serialization fails.
-    return "# yaml serialization failed; falling back to json\n" + JSON.stringify(data);
+  } catch (err) {
+    // Never lose data: fall back to plain JSON. (A comment-prefixed hybrid would be
+    // neither clean YAML nor clean JSON, so we warn and return pure JSON instead.)
+    console.warn(
+      `[format] yaml serialization failed, returning json: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return JSON.stringify(data);
   }
 }
 
@@ -135,6 +139,20 @@ const RESERVED_NODE_KEYS = new Set([
   "text",
   "textColor",
   "children",
+]);
+
+/**
+ * layoutStyle sub-fields encoded positionally on the node header
+ * (`WxH @relativeX,relativeY`). Every OTHER layoutStyle sub-field (rotate, rotateX,
+ * min/max sizing constraints) is rendered as an explicit extra so it is not silently
+ * dropped — `layoutStyle` is reserved, so the generic pass-through would otherwise
+ * skip it and a rotated node would lose its angle (a fidelity regression).
+ */
+const LAYOUT_POSITIONAL_KEYS = new Set([
+  "width",
+  "height",
+  "relativeX",
+  "relativeY",
 ]);
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -264,10 +282,17 @@ function kvMapToTree(obj: Record<string, unknown>): string {
     lines.push(`${key}: ${JSON.stringify(val)}`);
   }
   if (mapKey) {
-    lines.push(`${mapKey}:`);
     const map = obj[mapKey] as Record<string, unknown>;
-    for (const [k, v] of Object.entries(map)) {
-      renderKvEntry(k, v, "  ", lines);
+    const entries = Object.entries(map);
+    if (entries.length === 0) {
+      // Empty map (e.g. cache miss): a single inline `{}` instead of a bare header
+      // with nothing beneath it.
+      lines.push(`${mapKey}: {}`);
+    } else {
+      lines.push(`${mapKey}:`);
+      for (const [k, v] of entries) {
+        renderKvEntry(k, v, "  ", lines);
+      }
     }
   }
   return lines.join("\n");
@@ -303,11 +328,22 @@ function renderNode(node: DslNode, depth: number, lines: string[]): void {
   const pos = `@${fmtNum(ls.relativeX)},${fmtNum(ls.relativeY)}`;
 
   const extras: string[] = [];
+  // layoutStyle is a reserved key, so the generic pass-through skips it — but only
+  // width/height/relativeX/relativeY feed the positional header. Surface every other
+  // sub-field (rotate, rotateX, and any min/max sizing constraints) or it is silently
+  // lost. A rotated node dropping its angle is a fidelity regression.
+  for (const [k, v] of Object.entries(ls)) {
+    if (LAYOUT_POSITIONAL_KEYS.has(k) || v === undefined || v === null) continue;
+    extras.push(`${k}=${v}`);
+  }
   pushIf(extras, "fill", node.fill);
   if (node.strokeColor) {
     extras.push(
       `stroke=${node.strokeColor}${node.strokeWidth ? "/" + node.strokeWidth : ""}`
     );
+  } else if (node.strokeWidth) {
+    // strokeWidth normally travels with strokeColor; surface it standalone if not.
+    pushIf(extras, "strokeWidth", node.strokeWidth);
   }
   pushIf(extras, "strokeType", node.strokeType);
   pushIf(extras, "strokeAlign", node.strokeAlign);
@@ -318,11 +354,20 @@ function renderNode(node: DslNode, depth: number, lines: string[]): void {
       (extras.length ? " " + extras.join(" ") : "")
   );
 
-  const props = (node.componentInfo as { properties?: Record<string, unknown> } | undefined)
-    ?.properties;
-  if (props && typeof props === "object") {
-    for (const [k, v] of Object.entries(props)) {
-      lines.push(`${pad}  prop ${k}=${JSON.stringify(v)}`);
+  // componentInfo is a reserved key. `.properties` renders as `prop k=v`; the sibling
+  // metadata (description / documentLink / componentSetDescription /
+  // componentSetDocumentLink) must also surface or it is silently dropped.
+  const compInfo = node.componentInfo as Record<string, unknown> | undefined;
+  if (compInfo && typeof compInfo === "object") {
+    const props = compInfo.properties;
+    if (props && typeof props === "object") {
+      for (const [k, v] of Object.entries(props)) {
+        lines.push(`${pad}  prop ${k}=${JSON.stringify(v)}`);
+      }
+    }
+    for (const [k, v] of Object.entries(compInfo)) {
+      if (k === "properties" || v === undefined) continue;
+      lines.push(`${pad}  ${k}=${JSON.stringify(v)}`);
     }
   }
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -183,6 +183,9 @@ function toTree(data: unknown): string {
   if (Array.isArray(obj.sections)) {
     return sectionListToTree(obj);
   }
+  if (Array.isArray(obj.svgs)) {
+    return svgListToTree(obj); // extractSvg: { count, svgs: [{ name, id, svg }] }
+  }
   if (isPlainObject(obj.svgs) || isPlainObject(obj.texts)) {
     return kvMapToTree(obj);
   }
@@ -261,6 +264,44 @@ function sectionListToTree(obj: Record<string, unknown>): string {
     for (const [k, v] of Object.entries(s)) {
       if (SECTION_ENTRY_KEYS.has(k) || v === undefined) continue;
       lines.push(`    ${k}=${JSON.stringify(v)}`);
+    }
+  });
+  return lines.join("\n");
+}
+
+/**
+ * extractSvg payload: `{ count, svgs: [{ name, id, svg }, ...] }`.
+ * Each entry renders as `[i] "name" (id)` with the SVG markup indented beneath
+ * (single-line inline; multi-line indented — bytes emitted verbatim, never escaped,
+ * so SVG fidelity is preserved exactly).
+ */
+function svgListToTree(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === "svgs") continue;
+    lines.push(`${key}: ${JSON.stringify(val)}`);
+  }
+  const svgs = Array.isArray(obj.svgs)
+    ? (obj.svgs as Array<Record<string, unknown>>)
+    : [];
+  if (svgs.length === 0) {
+    lines.push("svgs: []");
+    return lines.join("\n");
+  }
+  lines.push("svgs:");
+  svgs.forEach((s, i) => {
+    lines.push(`  [${i}] ${quote(s.name)} (${s.id ?? "?"})`);
+    const svg = s.svg;
+    if (typeof svg === "string" && !svg.includes("\n")) {
+      lines.push(`    ${svg}`);
+    } else if (typeof svg === "string") {
+      if (svg === "") {
+        lines.push('    ""');
+      } else {
+        for (const ln of svg.split("\n")) lines.push("    " + ln);
+      }
+    } else {
+      lines.push(`    ${JSON.stringify(svg)}`);
     }
   });
   return lines.join("\n");

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,0 +1,217 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import yaml from "js-yaml";
+import {
+  formatOutput,
+  normalizeFormat,
+  FORMAT_VALUES,
+} from "../src/utils/format";
+
+// ---- helpers ----
+const isJson = (s: string) => {
+  const t = s.trimStart();
+  return t.startsWith("{") || t.startsWith("[");
+};
+const roundTripYaml = (data: unknown) =>
+  yaml.load(formatOutput(data, "yaml")) as unknown;
+
+// ---- fixtures matching the real server response shapes ----
+const rawDsl = {
+  styles: { "paint_1:1": { value: ["#FFFFFF"] } },
+  nodes: [
+    {
+      type: "FRAME",
+      id: "1:2",
+      name: "Root",
+      layoutStyle: { width: 10, height: 10, relativeX: 0, relativeY: 0 },
+    },
+  ],
+};
+const sectionDsl = {
+  sectionIndex: 0,
+  section: { id: "1:2", name: "Hero", type: "FRAME" },
+  dsl: {
+    styles: {},
+    nodes: [
+      {
+        type: "TEXT",
+        id: "1:3",
+        name: "Title",
+        layoutStyle: { width: 80, height: 24, relativeX: 0, relativeY: 0 },
+        text: [{ text: "Hi", font: "f:1" }],
+      },
+    ],
+  },
+};
+const getDslPayload = { dsl: rawDsl, componentDocumentLinks: [], rules: ["r1"] };
+const sectionList = {
+  sections: [
+    {
+      id: "1:2",
+      name: "Hero",
+      type: "FRAME",
+      nodeCount: 5,
+      x: 0,
+      y: 0,
+      width: 1040,
+      height: 800,
+    },
+  ],
+  totalSections: 1,
+  totalNodes: 5,
+  rootContainer: { width: 1040 },
+};
+const svgsPayload = { svgs: { "S0:Icon|1:3": "<svg/>" }, nodeCount: 1 };
+const svgsEmpty = { message: "No cached SVG data found.", svgs: {}, nodeCount: 0 };
+const textsPayload = { texts: { "T0|1:3": "已启用" }, textCount: 1 };
+const textsEmpty = { message: "No cached text data found.", texts: {}, textCount: 0 };
+const extractSvgPayload = {
+  count: 2,
+  svgs: [
+    { name: "a", id: "1:2", svg: "<svg/>" },
+    { name: "b", id: "1:3", svg: "<svg>\n  <path/>\n</svg>" },
+  ],
+};
+const extractSvgEmpty = { count: 0, svgs: [] };
+const metaPayload = { result: { site: "x" }, rules: "# Rules\n- one" };
+
+const allShapes = [
+  sectionDsl,
+  rawDsl,
+  getDslPayload,
+  sectionList,
+  svgsPayload,
+  textsPayload,
+  extractSvgPayload,
+  metaPayload,
+];
+
+// ---- 1. format dispatch per shape ----
+
+test("json: every shape returns JSON byte-identical to JSON.stringify", () => {
+  for (const data of allShapes) {
+    assert.equal(formatOutput(data, "json"), JSON.stringify(data));
+  }
+});
+
+test("yaml: round-trips losslessly for every serializable shape", () => {
+  for (const data of allShapes) {
+    assert.deepEqual(roundTripYaml(data), data);
+  }
+});
+
+test("tree: dispatches every shape except getMeta (markdown rules fall back to JSON)", () => {
+  for (const data of [
+    sectionDsl,
+    rawDsl,
+    getDslPayload,
+    sectionList,
+    svgsPayload,
+    textsPayload,
+    extractSvgPayload,
+  ]) {
+    const out = formatOutput(data, "tree");
+    assert.ok(!isJson(out), `expected tree, got JSON: ${out.slice(0, 80)}`);
+  }
+  // getMeta carries markdown `rules` — tree must fall back to JSON, not mangle it.
+  assert.equal(formatOutput(metaPayload, "tree"), JSON.stringify(metaPayload));
+});
+
+// ---- 2. specific tree renderings ----
+
+test("tree/section DSL: globalVars + positional node header", () => {
+  const out = formatOutput(sectionDsl, "tree");
+  assert.match(out, /globalVars:/);
+  assert.match(out, /TEXT 1:3 "Title" 80x24 @0,0/);
+});
+
+test("tree/getDesignSvgs: block + inline value; empty -> 'svgs: {}'", () => {
+  assert.match(formatOutput(svgsPayload, "tree"), /svgs:\n {2}S0:Icon\|1:3: <svg\/>/);
+  assert.match(formatOutput(svgsEmpty, "tree"), /svgs: \{\}/);
+});
+
+test("tree/getDesignTexts: block + verbatim CJK; empty -> 'texts: {}'", () => {
+  assert.match(formatOutput(textsPayload, "tree"), /texts:\n {2}T0\|1:3: 已启用/);
+  assert.match(formatOutput(textsEmpty, "tree"), /texts: \{\}/);
+});
+
+test("tree/extractSvg: [i] entries, multi-line svg indented; empty -> 'svgs: []'", () => {
+  const out = formatOutput(extractSvgPayload, "tree");
+  assert.match(out, /\[0\] "a" \(1:2\)/);
+  assert.match(out, /\[1\] "b" \(1:3\)/);
+  assert.match(out, / {4}<svg>/); // multi-line svg value indented beneath the entry
+  assert.match(out, / {6}<path\/>/);
+  assert.match(formatOutput(extractSvgEmpty, "tree"), /svgs: \[\]/);
+});
+
+test("tree/section list: [i] entry with page-absolute bbox", () => {
+  assert.match(
+    formatOutput(sectionList, "tree"),
+    /\[0\] FRAME 1:2 "Hero" 1040x800 @0,0 nodeCount=5/
+  );
+});
+
+// ---- 3. resolution / fallbacks ----
+
+test("normalizeFormat: accepts valid, rejects invalid/unset", () => {
+  assert.equal(normalizeFormat("yaml"), "yaml");
+  assert.equal(normalizeFormat("tree"), "tree");
+  assert.equal(normalizeFormat("bogus"), null);
+  assert.equal(normalizeFormat(undefined), null);
+  assert.equal(normalizeFormat(""), null);
+});
+
+test("resolveFormat precedence: explicit param > DEFAULT_FORMAT env > json", () => {
+  process.env.DEFAULT_FORMAT = "yaml";
+  try {
+    assert.match(formatOutput(rawDsl, "tree"), /globalVars:/); // explicit tree wins
+    assert.ok(formatOutput(rawDsl).startsWith("styles:")); // env yaml (rawDsl starts with styles:)
+    assert.equal(formatOutput(rawDsl, "json"), JSON.stringify(rawDsl)); // explicit json wins
+  } finally {
+    delete process.env.DEFAULT_FORMAT;
+  }
+});
+
+test("resolveFormat: bogus DEFAULT_FORMAT env -> json", () => {
+  process.env.DEFAULT_FORMAT = "xml";
+  try {
+    assert.equal(formatOutput(rawDsl), JSON.stringify(rawDsl));
+  } finally {
+    delete process.env.DEFAULT_FORMAT;
+  }
+});
+
+test("resolveFormat: no explicit, no env -> json", () => {
+  delete process.env.DEFAULT_FORMAT;
+  assert.equal(formatOutput(rawDsl), JSON.stringify(rawDsl));
+});
+
+test("invalid format arg -> json", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.equal(formatOutput(rawDsl, "xml" as any), JSON.stringify(rawDsl));
+});
+
+// ---- 4. yaml error fallback: pure JSON + warn, never the comment hybrid ----
+
+test("yaml fallback: serialization failure returns pure JSON (no '#' prefix) and warns", () => {
+  // Function value: js-yaml.dump throws, JSON.stringify omits it -> {"b":2}
+  const tricky = { a: (() => 1) as unknown as number, b: 2 };
+  const warned: string[] = [];
+  const orig = console.warn;
+  console.warn = (m: string) => warned.push(m);
+  try {
+    const out = formatOutput(tricky, "yaml");
+    assert.equal(out, JSON.stringify(tricky));
+    assert.ok(!out.startsWith("#"), "must not return the old comment+JSON hybrid");
+    assert.equal(warned.length, 1);
+    assert.match(warned[0], /yaml serialization failed/);
+  } finally {
+    console.warn = orig;
+  }
+});
+
+// ---- 5. sanity ----
+
+test("FORMAT_VALUES is exactly json/yaml/tree", () => {
+  assert.deepEqual([...FORMAT_VALUES], ["json", "yaml", "tree"]);
+});


### PR DESCRIPTION
## Summary

Adds `--format` CLI flag and `DEFAULT_FORMAT` env var to set the default output format (`json`/`yaml`/`tree`) for design data tools. Adds a `format` parameter to all design data tools, adds yaml serialization support, and updates all documentation to match the new functionality.

## Changes

- `src/utils/format.ts` — new format serialization utilities (+259)
- `src/utils/args.ts`, `src/index.ts` — `--format` CLI flag & `DEFAULT_FORMAT` env var
- `src/tools/get-design-sections.ts`, `get-design-svgs.ts`, `get-design-texts.ts`, `get-dsl.ts` — add `format` parameter
- `README.md`, `README.zh-CN.md`, `CLAUDE.md`, `package.json`, `build.js` — docs & build updates

## Stats

12 files changed, +376 / −13

---
- Commit: `edd6035`