### PR TITLE
feat: custom HTTP headers (#64) + security hardening + dependency audit (0 vulnerabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Restore design, save as HTML file: https://{domain}/goto/{shortLink}
 ### Command Line Options
 
 ```
-npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header=Key: Value] [--debug] [--no-rule]
+npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header "Key: Value"] [--debug] [--no-rule]
 ```
 
 #### Parameters:
@@ -82,7 +82,7 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 - `--url=API_URL` (optional): API base URL, defaults to http://localhost:3000
 - `--rule=RULE_NAME` (optional): Add design rules to apply, can be used multiple times
 - `--proxy=PROXY_URL` (optional): HTTP/HTTPS proxy URL (e.g., `http://127.0.0.1:7890`), also supports `HTTPS_PROXY` / `HTTP_PROXY` environment variables
-- `--header=Key: Value` (optional): HTTP Request Header, can be used multiple times
+- `--header "Key: Value"` (optional): Custom HTTP request header, can be used multiple times. **Quote the value** when it contains spaces. Custom headers override the defaults — including `Content-Type` and the auth token — so match the default key exactly when overriding. Also settable via the `MG_EXTRA_HEADERS` environment variable as a JSON object (e.g. `MG_EXTRA_HEADERS='{"X-Custom":"val"}'`); CLI headers take precedence over env.
 - `--format=FORMAT` (optional): Default output format for design-data tools — one of `json` (default), `yaml`, `tree`. An explicit per-call `format` tool parameter overrides this. Also settable via the `DEFAULT_FORMAT` environment variable.
 - `--debug` (optional): Enable debug mode for detailed error information
 - `--no-rule` (optional): Disable default rules
@@ -90,7 +90,7 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 You can also use space-separated format for parameters:
 
 ```
-npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --format FORMAT --debug
+npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --format FORMAT --header "Key: Value" --debug
 ```
 
 #### Environment Variables

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ MCP 服务连接成功后，可以在 AI 对话中使用以下提示词：
 ### 命令行选项
 
 ```
-npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header=Key: Value] [--debug] [--no-rule]
+npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header "Key: Value"] [--debug] [--no-rule]
 ```
 
 #### 参数:
@@ -82,7 +82,7 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 - `--url=API_URL` (可选): API 基础 URL，默认为 http://localhost:3000
 - `--rule=RULE_NAME` (可选): 添加要应用的设计规则，可多次使用
 - `--proxy=PROXY_URL` (可选): HTTP/HTTPS 代理地址（如 `http://127.0.0.1:7890`），也支持 `HTTPS_PROXY` / `HTTP_PROXY` 环境变量
-- `--header` (可选): 添加自定义HTTP请求头，可多次使用
+- `--header "Key: Value"` (可选): 自定义 HTTP 请求头，可多次使用。值含空格时**必须加引号**。自定义头会覆盖默认头（含 `Content-Type` 和鉴权 token），覆盖时请与默认 key 完全一致。也可通过 `MG_EXTRA_HEADERS` 环境变量以 JSON 对象形式设置（如 `MG_EXTRA_HEADERS='{"X-Custom":"val"}'`）；命令行传入的头优先级更高。
 - `--format=FORMAT` (可选): 设计数据工具的默认输出格式 —— 取值 `json`（默认）、`yaml`、`tree`。工具调用时显式传入的 `format` 参数优先级更高。也可通过 `DEFAULT_FORMAT` 环境变量设置。
 - `--debug` (可选): 启用调试模式，提供详细错误信息
 - `--no-rule` (可选): 禁用默认规则
@@ -90,7 +90,7 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 你也可以使用空格分隔的参数格式:
 
 ```
-npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --format FORMAT --debug
+npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --proxy PROXY_URL --format FORMAT --header "Key: Value" --debug
 ```
 
 #### 环境变量

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:watch": "node build.js --watch",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "test": "esbuild test/format.test.ts --bundle --platform=node --format=cjs --outfile=.test/format.test.cjs && node --test .test/format.test.cjs",
+    "test": "esbuild test/format.test.ts test/headers.test.ts test/url-safety.test.ts --bundle --platform=node --format=cjs --outdir=.test --out-extension:.js=.cjs && node --test .test/format.test.cjs .test/headers.test.cjs .test/url-safety.test.cjs",
     "start": "node dist/index.js --token=test --url=http://localhost:3000 --debug",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
@@ -44,22 +44,28 @@
   "private": false,
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
-    "axios": "1.6.0",
+    "axios": "1.18.1",
     "https-proxy-agent": "^9.0.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.2.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.8.10",
-    "@typescript-eslint/eslint-plugin": "^6.9.1",
-    "@typescript-eslint/parser": "^6.9.1",
+    "@typescript-eslint/eslint-plugin": "^8.62.0",
+    "@typescript-eslint/parser": "^8.62.0",
     "esbuild": "^0.25.1",
     "esbuild-plugin-tsc": "^0.5.0",
-    "eslint": "^8.52.0",
-    "pkg": "^5.8.1",
+    "eslint": "^8.57.1",
     "prettier": "^3.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
+  },
+  "overrides": {
+    "hono": "^4.12.27",
+    "form-data": "^4.0.6",
+    "fast-uri": "^3.1.2",
+    "ip-address": "^10.2.0",
+    "qs": "^6.15.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { GetDesignSectionsTool } from "./tools/get-design-sections";
 import { GetDesignSvgsTool } from "./tools/get-design-svgs";
 import { GetDesignTextsTool } from "./tools/get-design-texts";
 import { ExtractSvgTool } from "./tools/extract-svg";
-import { parserArgs } from "./utils/args";
+import { parserArgs, getEffectiveHeaders, maskSensitiveHeaders } from "./utils/args";
 import { normalizeFormat } from "./utils/format";
 
 const SERVER_INSTRUCTIONS = `
@@ -83,7 +83,7 @@ After ALL N sections have been fetched and SVG data retrieved:
 
 function main() {
   // Parse command line arguments and set environment variables
-  const { token, baseUrl, rules, debug, noRule, proxy, format, headers } = parserArgs();
+  const { token, baseUrl, rules, debug, noRule, proxy, format } = parserArgs();
 
   // `--format` (json|yaml|tree) sets the default output format for design-data tools.
   // An explicit per-call `format` tool parameter still takes precedence (see utils/format.ts).
@@ -108,7 +108,8 @@ function main() {
     console.log(`Rules: ${rules.length > 0 ? rules.join(", ") : "none"}`);
     console.log(`No Rule: ${noRule ? "enabled" : "disabled"}`);
     console.log(`Proxy: ${proxy || "none"}`);
-    console.log(`Custom Headers: ${Object.keys(headers).length > 0 ? JSON.stringify(headers) : "none"}`);
+    const effectiveHeaders = getEffectiveHeaders();
+    console.log(`Custom Headers: ${Object.keys(effectiveHeaders).length > 0 ? JSON.stringify(maskSensitiveHeaders(effectiveHeaders)) : "none"}`);
     console.log(`Format: ${process.env.DEFAULT_FORMAT || "json (default)"}`);
     console.log(`Debug mode: enabled`);
   }

--- a/src/tools/extract-svg.ts
+++ b/src/tools/extract-svg.ts
@@ -33,6 +33,12 @@ export class ExtractSvgTool extends BaseTool {
       .describe(
         "Layer ID of the specific component or element to retrieve (format: ?layer_id=<layerId>). Required if shortLink is not provided."
       ),
+    sourceLayerId: z
+      .string()
+      .optional()
+      .describe(
+        "Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries."
+      ),
     shortLink: z
       .string()
       .optional()
@@ -48,30 +54,33 @@ export class ExtractSvgTool extends BaseTool {
 
   async execute(params: z.infer<typeof this.schema>) {
     try {
-      const { fileId, layerId, shortLink, backgroundColor, format } = params;
+      const { fileId, layerId, sourceLayerId, shortLink, backgroundColor, format } = params;
 
-      if (!shortLink && (!fileId || !layerId)) {
+      if (!shortLink && (!fileId || (!layerId && !sourceLayerId))) {
         throw new Error(
-          "Either provide both fileId and layerId, or provide a shortLink"
+          "Either provide fileId with layerId (or sourceLayerId), or provide a shortLink"
         );
       }
 
       let finalFileId = this.normalizeFileId(fileId);
       let finalLayerId = layerId;
+      let finalSourceLayerId = sourceLayerId;
 
       if (shortLink) {
         const ids = await httpUtilInstance.extractIdsFromUrl(shortLink);
         finalFileId = this.normalizeFileId(ids.fileId);
         finalLayerId = ids.layerId;
+        finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
       }
 
-      if (!finalFileId || !finalLayerId) {
-        throw new Error("Could not determine fileId or layerId");
+      const effectiveLayerId = finalSourceLayerId || finalLayerId;
+      if (!finalFileId || !effectiveLayerId) {
+        throw new Error("Could not determine fileId or layerId (need layerId or sourceLayerId)");
       }
 
       const result = await httpUtilInstance.extractSvg(
         finalFileId,
-        finalLayerId,
+        effectiveLayerId,
         backgroundColor
       );
 

--- a/src/tools/get-design-sections.ts
+++ b/src/tools/get-design-sections.ts
@@ -75,9 +75,9 @@ export class GetDesignSectionsTool extends BaseTool {
 
   async execute({ fileId, layerId, shortLink, sourceLayerId, sectionIndex, format }: z.infer<typeof this.schema>) {
     try {
-      if (!shortLink && (!fileId || !layerId)) {
+      if (!shortLink && (!fileId || (!layerId && !sourceLayerId))) {
         throw new Error(
-          "Either provide both fileId and layerId, or provide a shortLink"
+          "Either provide fileId with layerId (or sourceLayerId), or provide a shortLink"
         );
       }
 
@@ -92,11 +92,10 @@ export class GetDesignSectionsTool extends BaseTool {
         finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
       }
 
-      if (!finalFileId || !finalLayerId) {
-        throw new Error("Could not determine fileId or layerId");
-      }
-
       const effectiveLayerId = finalSourceLayerId || finalLayerId;
+      if (!finalFileId || !effectiveLayerId) {
+        throw new Error("Could not determine fileId or layerId (need layerId or sourceLayerId)");
+      }
 
       const result = await httpUtilInstance.getDesignSections(
         finalFileId,

--- a/src/tools/get-design-svgs.ts
+++ b/src/tools/get-design-svgs.ts
@@ -56,9 +56,9 @@ export class GetDesignSvgsTool extends BaseTool {
     format,
   }: z.infer<typeof this.schema>) {
     try {
-      if (!shortLink && (!fileId || !layerId)) {
+      if (!shortLink && (!fileId || (!layerId && !sourceLayerId))) {
         throw new Error(
-          "Either provide both fileId and layerId, or provide a shortLink"
+          "Either provide fileId with layerId (or sourceLayerId), or provide a shortLink"
         );
       }
 
@@ -73,11 +73,10 @@ export class GetDesignSvgsTool extends BaseTool {
         finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
       }
 
-      if (!finalFileId || !finalLayerId) {
-        throw new Error("Could not determine fileId or layerId");
-      }
-
       const effectiveLayerId = finalSourceLayerId || finalLayerId;
+      if (!finalFileId || !effectiveLayerId) {
+        throw new Error("Could not determine fileId or layerId (need layerId or sourceLayerId)");
+      }
 
       const result = await httpUtilInstance.getDesignSvgs(
         finalFileId,

--- a/src/tools/get-design-texts.ts
+++ b/src/tools/get-design-texts.ts
@@ -56,9 +56,9 @@ export class GetDesignTextsTool extends BaseTool {
     format,
   }: z.infer<typeof this.schema>) {
     try {
-      if (!shortLink && (!fileId || !layerId)) {
+      if (!shortLink && (!fileId || (!layerId && !sourceLayerId))) {
         throw new Error(
-          "Either provide both fileId and layerId, or provide a shortLink"
+          "Either provide fileId with layerId (or sourceLayerId), or provide a shortLink"
         );
       }
 
@@ -73,11 +73,10 @@ export class GetDesignTextsTool extends BaseTool {
         finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
       }
 
-      if (!finalFileId || !finalLayerId) {
-        throw new Error("Could not determine fileId or layerId");
-      }
-
       const effectiveLayerId = finalSourceLayerId || finalLayerId;
+      if (!finalFileId || !effectiveLayerId) {
+        throw new Error("Could not determine fileId or layerId (need layerId or sourceLayerId)");
+      }
 
       const result = await httpUtilInstance.getDesignTexts(
         finalFileId,

--- a/src/tools/get-dsl.ts
+++ b/src/tools/get-dsl.ts
@@ -52,9 +52,9 @@ export class GetDslTool extends BaseTool {
 
   async execute({ fileId, layerId, sourceLayerId, shortLink, format }: z.infer<typeof this.schema>) {
     try {
-      if (!shortLink && (!fileId || !layerId)) {
+      if (!shortLink && (!fileId || (!layerId && !sourceLayerId))) {
         throw new Error(
-          "Either provide both fileId and layerId, or provide a MasterGo URL"
+          "Either provide fileId with layerId (or sourceLayerId), or provide a MasterGo URL"
         );
       }
 
@@ -69,11 +69,12 @@ export class GetDslTool extends BaseTool {
         finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
       }
 
-      if (!finalFileId || !finalLayerId) {
-        throw new Error("Could not determine fileId or layerId");
+      const effectiveLayerId = finalSourceLayerId || finalLayerId;
+      if (!finalFileId || !effectiveLayerId) {
+        throw new Error("Could not determine fileId or layerId (need layerId or sourceLayerId)");
       }
 
-      const dsl = await httpUtilInstance.getDsl(finalFileId, finalLayerId, {
+      const dsl = await httpUtilInstance.getDsl(finalFileId, effectiveLayerId, {
         sourceLayerId: finalSourceLayerId,
       });
       return {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { parseToken, parseUrl, parseRules, parseNoRule, parseProxy, parseHeaders } from "./args";
+import { parseToken, parseUrl, parseRules, parseNoRule, parseProxy, getEffectiveHeaders } from "./args";
 import https from "https";
 import { HttpsProxyAgent } from "https-proxy-agent";
 
@@ -40,15 +40,29 @@ export interface CodeResponse {
   [key: string]: any;
 }
 
-const getCommonHeader = () => ({
-  "Content-Type": "application/json",
-  Accept: "application/json",
-  "X-MG-UserAccessToken":
-    process.env.MG_MCP_TOKEN || process.env.MASTERGO_API_TOKEN || parseToken(),
-  ...parseHeaders(),
-});
+// Memoized: the header set is fixed at process boot (token env/argv + MG_EXTRA_HEADERS),
+// and this is called on every HTTP request. Callers spread the result into a new object,
+// so returning the shared cached reference is safe from mutation.
+let _commonHeaderCache: Record<string, string> | null = null;
+const getCommonHeader = (): Record<string, string> => {
+  if (_commonHeaderCache) return _commonHeaderCache;
+  _commonHeaderCache = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "X-MG-UserAccessToken":
+      process.env.MG_MCP_TOKEN || process.env.MASTERGO_API_TOKEN || parseToken(),
+    ...getEffectiveHeaders(),
+  };
+  return _commonHeaderCache;
+};
 
-const getBaseUrl = () => {
+// Memoized: the base URL is fixed at process boot (API_BASE_URL env / --url argv)
+// and this is called on every HTTP request. A parse failure is NOT cached, so the
+// next call re-evaluates (and re-throws) — caching an error would make a bad state
+// permanent.
+let _baseUrlCache: string | null = null;
+const getBaseUrl = (): string => {
+  if (_baseUrlCache !== null) return _baseUrlCache;
   const url = process.env.API_BASE_URL || parseUrl();
   try {
     // 解析URL
@@ -65,11 +79,25 @@ const getBaseUrl = () => {
       baseUrl += `:${port}`;
     }
 
-    return baseUrl;
+    _baseUrlCache = baseUrl;
+    return _baseUrlCache;
   } catch {
     throw new Error(
       `无效的URL格式: ${url}。请提供正确的URL格式，例如: https://mastergo.com`
     );
+  }
+};
+
+// Compare only the host (hostname + port) of two URLs, ignoring protocol/path.
+// Returns false on any parse error rather than throwing. Exported for unit tests.
+// SECURITY: this gates whether a user/LLM-supplied shortLink may receive our
+// credentials — a wrong `true` here leaks X-MG-UserAccessToken (and custom gateway
+// auth) to an attacker-controlled host.
+export const isSameHost = (a: string, b: string): boolean => {
+  try {
+    return new URL(a).host === new URL(b).host;
+  } catch {
+    return false;
   }
 };
 
@@ -271,9 +299,20 @@ const createHttpUtil = () => {
 
       // Handle short links
       if (url.includes("/goto/")) {
+        // The shortLink is user/LLM-controlled and only `url.includes("/goto/")`
+        // is checked — it may NOT be a MasterGo host (e.g. a prompt-injected
+        // `https://evil.com/goto/x`). Send credentials (X-MG-UserAccessToken +
+        // custom gateway headers) ONLY when the short link's host matches the
+        // configured API host. Same-host links (the normal private-deploy case,
+        // where the short-link domain == the API domain) still get headers so
+        // they pass the internal gateway (issue #64); anything else gets a bare
+        // request and the missing credentials surface as a clear failure instead
+        // of a silent leak.
+        const sendCredentials = isSameHost(url, getBaseUrl());
         const response = await axios.get(url, {
           maxRedirects: 0,
           validateStatus: (status) => status >= 300 && status < 400,
+          ...(sendCredentials ? { headers: getCommonHeader() } : {}),
         });
 
         const redirectUrl = response.headers.location;

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -92,31 +92,169 @@ function parseProxy(): string {
   return proxy;
 }
 
-// 解析 --header "Key: Value" 参数（可重复多次）
+// Truncate raw header input in warnings so we don't echo long/secret-like values
+// back to the console.
+const truncateForWarn = (s: string, max = 32) => (s.length > max ? `${s.slice(0, max)}…` : s);
+
+// Known sensitive header keys (lowercased substring match) masked in debug output.
+const SENSITIVE_HEADER_KEYS = [
+  "authorization",
+  "token",
+  "secret",
+  "password",
+  "cookie",
+  "api-key",
+  "apikey",
+];
+
+const isSensitiveHeader = (key: string): boolean => {
+  const lk = key.toLowerCase();
+  return SENSITIVE_HEADER_KEYS.some((s) => lk.includes(s));
+};
+
+// Format a raw header value for warning output. Invalid headers often have no
+// clean `:` separator (e.g. `Authorization Bearer eyJ...`), so we can't rely on
+// the parsed key — match sensitive keywords against the WHOLE raw string and, on
+// any hit, hide it entirely (length only). We must never echo even a truncated
+// prefix of a credential: stderr is routinely captured by log collectors, and a
+// mis-typed auth header is the most common invalid-input case. Non-sensitive
+// values are still shown (truncated) so users can debug ordinary typos.
+const redactForWarn = (raw: string): string => {
+  const lower = raw.toLowerCase();
+  if (SENSITIVE_HEADER_KEYS.some((s) => lower.includes(s))) {
+    return `<redacted, length=${raw.length}>`;
+  }
+  return `"${truncateForWarn(raw)}"`;
+};
+
+// Parse `--header "Key: Value"` (repeatable). Invalid inputs (missing value,
+// a following flag, missing ":", empty key) are skipped with a `console.warn` so
+// a misconfigured gateway/auth header doesn't fail silently (issue #64).
 function parseHeaders(): Record<string, string> {
   const args = getArgs();
   const headers: Record<string, string> = {};
 
   for (let i = 0; i < args.length; i++) {
-    let raw = "";
-    if (args[i] === "--header" && i + 1 < args.length) {
-      raw = args[i + 1];
+    let raw: string;
+
+    if (args[i] === "--header") {
+      const next = i + 1 < args.length ? args[i + 1] : undefined;
+      if (next === undefined) {
+        console.warn(
+          `[--header] missing value (expected --header "Key: Value" or --header=Key:Value).`
+        );
+        continue;
+      }
+      // Don't swallow a following flag — it belongs to its own parser and the user
+      // almost certainly forgot the header value. Leave it for the next iteration so
+      // later --header occurrences and other flags are still seen (review #3).
+      if (next.startsWith("--")) {
+        console.warn(
+          `[--header] missing value: next argument ${redactForWarn(next)} looks like a flag, not a header value.`
+        );
+        continue;
+      }
+      raw = next;
       i++;
     } else if (args[i].startsWith("--header=")) {
       raw = args[i].slice("--header=".length);
+    } else {
+      continue;
     }
 
-    if (raw) {
-      const sep = raw.indexOf(":");
-      if (sep > 0) {
-        const key = raw.slice(0, sep).trim();
-        const value = raw.slice(sep + 1).trim();
-        headers[key] = value;
+    if (!raw) {
+      console.warn(
+        `[--header] received an empty value (expected --header "Key: Value" or --header=Key:Value).`
+      );
+      continue;
+    }
+
+    const sep = raw.indexOf(":");
+    if (sep === -1) {
+      console.warn(`Skipping invalid --header (missing ":" separator): ${redactForWarn(raw)}`);
+    } else if (sep === 0) {
+      console.warn(`Skipping invalid --header (empty header name before ":"): ${redactForWarn(raw)}`);
+    } else {
+      const key = raw.slice(0, sep).trim();
+      const value = raw.slice(sep + 1).trim();
+      if (value === "") {
+        console.warn(
+          `--header "${key}" has an empty value — if unintended, quote the value (e.g. --header "${key}: value"); shells split unquoted values that contain spaces.`
+        );
       }
+      headers[key] = value;
     }
   }
 
   return headers;
+}
+
+// Parse custom headers from the `MG_EXTRA_HEADERS` env var (a JSON object, e.g.
+// `{"X-Custom":"val"}`). Lets users pass secrets without putting them in
+// `process.argv` (visible via `ps`). CLI `--header` takes precedence over env.
+function parseEnvHeaders(): Record<string, string> {
+  const raw = process.env.MG_EXTRA_HEADERS;
+  if (!raw) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn(
+      `MG_EXTRA_HEADERS is not valid JSON — ignoring. Expected a JSON object like '{"X-Custom":"val"}'.`
+    );
+    return {};
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    console.warn(
+      `MG_EXTRA_HEADERS must be a JSON object — ignoring (got ${Array.isArray(parsed) ? "array" : typeof parsed}).`
+    );
+    return {};
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v !== "string") {
+      console.warn(`MG_EXTRA_HEADERS header "${k}" ignored — value must be a string (got ${typeof v}).`);
+      continue;
+    }
+    headers[k] = v;
+  }
+  return headers;
+}
+
+// Merge env + CLI custom headers. CLI `--header` overrides env, and both override
+// the defaults in getCommonHeader() (Content-Type / auth token). Single source of
+// truth consumed by api.ts and the index.ts debug output.
+//
+// Memoized: argv and MG_EXTRA_HEADERS don't change after process boot, but this
+// is on the per-request hot path (getCommonHeader() is called by every HTTP
+// method in api.ts) — without caching we'd JSON.parse the env blob and walk argv
+// on every request. Callers spread the result into a new object, so returning the
+// cached reference is safe (no downstream mutation).
+let _effectiveHeadersCache: Record<string, string> | null = null;
+
+function getEffectiveHeaders(): Record<string, string> {
+  if (_effectiveHeadersCache) return _effectiveHeadersCache;
+  _effectiveHeadersCache = { ...parseEnvHeaders(), ...parseHeaders() };
+  return _effectiveHeadersCache;
+}
+
+// Test-only hook: clear the memoized cache so unit tests can drive
+// getEffectiveHeaders() with fresh argv/env. No-op in production.
+export function resetEffectiveHeadersCache(): void {
+  _effectiveHeadersCache = null;
+}
+
+// Return a shallow copy with known sensitive header values masked, so debug logs
+// don't leak credentials.
+function maskSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
+  const masked: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    masked[k] = isSensitiveHeader(k) ? "<masked>" : v;
+  }
+  return masked;
 }
 
 // Returns the raw --format value, or `undefined` when the flag is absent.
@@ -143,7 +281,6 @@ export function parserArgs(): {
   debug: boolean;
   noRule: boolean;
   proxy: string;
-  headers: Record<string, string>;
   format: string | undefined;
 } {
   const token = parseToken();
@@ -152,7 +289,6 @@ export function parserArgs(): {
   const debug = parseDebug();
   const noRule = parseNoRule();
   const proxy = parseProxy();
-  const headers = parseHeaders();
   const format = parseFormat();
 
   return {
@@ -163,8 +299,7 @@ export function parserArgs(): {
     noRule,
     proxy,
     format,
-    headers,
   };
 }
 
-export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseProxy, parseFormat, parseHeaders, getArgs };
+export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseProxy, parseFormat, parseHeaders, parseEnvHeaders, getEffectiveHeaders, maskSensitiveHeaders, getArgs };

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -1,0 +1,314 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseHeaders,
+  parseEnvHeaders,
+  getEffectiveHeaders,
+  maskSensitiveHeaders,
+  resetEffectiveHeadersCache,
+} from "../src/utils/args";
+
+// ---- helpers ----
+
+// parseHeaders() reads process.argv.slice(2), so drive it by setting argv.
+const ORIG_ARGV = process.argv;
+const withArgv = (...args: string[]) => {
+  process.argv = ["node", "mastergo-magic-mcp", ...args];
+};
+const restoreArgv = () => {
+  process.argv = ORIG_ARGV;
+};
+
+// Capture every console.warn call during a block.
+const captureWarn = () => {
+  const warns: string[] = [];
+  const orig = console.warn;
+  console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+  return {
+    warns,
+    restore: () => {
+      console.warn = orig;
+    },
+  };
+};
+
+// ---- parseHeaders: valid inputs ----
+
+test("parseHeaders: --header Key: Value", () => {
+  try {
+    withArgv("--header", "Key: Value");
+    assert.deepEqual(parseHeaders(), { Key: "Value" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: --header=Key:Value (equals form)", () => {
+  try {
+    withArgv("--header=Key:Value");
+    assert.deepEqual(parseHeaders(), { Key: "Value" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: --header=Key: Value (equals form, quoted at shell)", () => {
+  try {
+    withArgv("--header=Key: Value");
+    assert.deepEqual(parseHeaders(), { Key: "Value" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: multiple --header flags", () => {
+  try {
+    withArgv("--header", "A: 1", "--header", "B: 2");
+    assert.deepEqual(parseHeaders(), { A: "1", B: "2" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: value may contain colons (split on first ':')", () => {
+  try {
+    withArgv("--header", "K: a:b");
+    assert.deepEqual(parseHeaders(), { K: "a:b" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: duplicate key — last value wins", () => {
+  try {
+    withArgv("--header", "K: 1", "--header", "K: 2");
+    assert.deepEqual(parseHeaders(), { K: "2" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: valid inputs do not warn", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header", "A: 1", "--header=Key:Value", "--header", "K: a:b");
+    parseHeaders();
+    assert.equal(cap.warns.length, 0);
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+// ---- parseHeaders: invalid inputs (skip + warn) ----
+
+test("parseHeaders: missing ':' separator -> skip + warn", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header", "novalue");
+    assert.deepEqual(parseHeaders(), {});
+    assert.equal(cap.warns.length, 1);
+    assert.match(cap.warns[0], /missing ":" separator/);
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+test("parseHeaders: empty key (':value') -> skip + warn", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header", ":value");
+    assert.deepEqual(parseHeaders(), {});
+    assert.match(cap.warns[0], /empty header name/);
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+test("parseHeaders: trailing --header (no value) -> warn", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header");
+    assert.deepEqual(parseHeaders(), {});
+    assert.match(cap.warns[0], /missing value/);
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+test("parseHeaders: empty value ('key:') -> kept + warn", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header", "key:");
+    assert.deepEqual(parseHeaders(), { key: "" });
+    assert.match(cap.warns[0], /empty value/);
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+// ---- parseHeaders: don't swallow a following flag (review #3) ----
+
+test("parseHeaders: --header followed by another flag -> warn, header skipped", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header", "--debug");
+    assert.deepEqual(parseHeaders(), {});
+    assert.ok(cap.warns.some((w) => /looks like a flag/.test(w)));
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+test("parseHeaders: following flag is not consumed — a later --header still parses", () => {
+  const cap = captureWarn();
+  try {
+    withArgv("--header", "--debug", "--header", "A: 1");
+    assert.deepEqual(parseHeaders(), { A: "1" });
+    assert.ok(cap.warns.some((w) => /looks like a flag/.test(w)));
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+test("parseHeaders: --header --header 'X:1' -> second --header not eaten", () => {
+  try {
+    withArgv("--header", "--header", "X:1");
+    assert.deepEqual(parseHeaders(), { X: "1" });
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseHeaders: sensitive raw input is redacted from warn (no credential echo)", () => {
+  const cap = captureWarn();
+  try {
+    // Missing ":" separator — raw looks like a mistyped auth header whose value
+    // is a real credential. It must be skipped AND never echoed to stderr.
+    withArgv("--header", "Authorization Bearer supersecretvalue");
+    assert.deepEqual(parseHeaders(), {});
+    assert.ok(cap.warns.some((w) => /missing ":" separator/.test(w)));
+    // The secret must never appear in any warn line, even truncated.
+    assert.ok(cap.warns.every((w) => !w.includes("supersecretvalue")));
+    assert.ok(cap.warns.some((w) => /<redacted/.test(w)));
+  } finally {
+    restoreArgv();
+    cap.restore();
+  }
+});
+
+// ---- parseEnvHeaders ----
+
+test("parseEnvHeaders: valid JSON object", () => {
+  try {
+    process.env.MG_EXTRA_HEADERS = JSON.stringify({ "X-Custom": "val", A: "b" });
+    assert.deepEqual(parseEnvHeaders(), { "X-Custom": "val", A: "b" });
+  } finally {
+    delete process.env.MG_EXTRA_HEADERS;
+  }
+});
+
+test("parseEnvHeaders: non-string value filtered + warn", () => {
+  const cap = captureWarn();
+  try {
+    process.env.MG_EXTRA_HEADERS = JSON.stringify({ k: 1, ok: "v" });
+    assert.deepEqual(parseEnvHeaders(), { ok: "v" });
+    assert.ok(cap.warns.some((w) => /must be a string/.test(w)));
+  } finally {
+    delete process.env.MG_EXTRA_HEADERS;
+    cap.restore();
+  }
+});
+
+test("parseEnvHeaders: invalid JSON -> warn + {}", () => {
+  const cap = captureWarn();
+  try {
+    process.env.MG_EXTRA_HEADERS = "not json";
+    assert.deepEqual(parseEnvHeaders(), {});
+    assert.match(cap.warns[0], /not valid JSON/);
+  } finally {
+    delete process.env.MG_EXTRA_HEADERS;
+    cap.restore();
+  }
+});
+
+test("parseEnvHeaders: array -> warn + {}", () => {
+  const cap = captureWarn();
+  try {
+    process.env.MG_EXTRA_HEADERS = "[1,2,3]";
+    assert.deepEqual(parseEnvHeaders(), {});
+    assert.match(cap.warns[0], /must be a JSON object/);
+  } finally {
+    delete process.env.MG_EXTRA_HEADERS;
+    cap.restore();
+  }
+});
+
+test("parseEnvHeaders: unset -> {}", () => {
+  delete process.env.MG_EXTRA_HEADERS;
+  assert.deepEqual(parseEnvHeaders(), {});
+});
+
+// ---- getEffectiveHeaders: env + CLI merge ----
+
+test("getEffectiveHeaders: CLI overrides env", () => {
+  try {
+    resetEffectiveHeadersCache();
+    process.env.MG_EXTRA_HEADERS = JSON.stringify({ A: "env", B: "env" });
+    withArgv("--header", "B: cli", "--header", "C: cli");
+    assert.deepEqual(getEffectiveHeaders(), { A: "env", B: "cli", C: "cli" });
+  } finally {
+    delete process.env.MG_EXTRA_HEADERS;
+    restoreArgv();
+    resetEffectiveHeadersCache();
+  }
+});
+
+test("getEffectiveHeaders: env headers apply when no CLI override", () => {
+  try {
+    resetEffectiveHeadersCache();
+    process.env.MG_EXTRA_HEADERS = JSON.stringify({ "X-Gateway-Auth": "secret" });
+    withArgv(); // no CLI headers
+    assert.deepEqual(getEffectiveHeaders(), { "X-Gateway-Auth": "secret" });
+  } finally {
+    delete process.env.MG_EXTRA_HEADERS;
+    restoreArgv();
+    resetEffectiveHeadersCache();
+  }
+});
+
+// ---- maskSensitiveHeaders ----
+
+test("maskSensitiveHeaders: masks known sensitive keys, leaves others intact", () => {
+  assert.deepEqual(
+    maskSensitiveHeaders({
+      Authorization: "Bearer secret",
+      "X-Public": "ok",
+      "X-MG-UserAccessToken": "t",
+      Cookie: "c",
+    }),
+    {
+      Authorization: "<masked>",
+      "X-Public": "ok",
+      "X-MG-UserAccessToken": "<masked>",
+      Cookie: "<masked>",
+    }
+  );
+});
+
+test("maskSensitiveHeaders: case-insensitive match", () => {
+  assert.deepEqual(
+    maskSensitiveHeaders({ authorization: "x", "API-KEY": "k", "X-Trace-Id": "t" }),
+    { authorization: "<masked>", "API-KEY": "<masked>", "X-Trace-Id": "t" }
+  );
+});
+
+test("maskSensitiveHeaders: empty input -> empty output", () => {
+  assert.deepEqual(maskSensitiveHeaders({}), {});
+});

--- a/test/url-safety.test.ts
+++ b/test/url-safety.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSameHost } from "../src/utils/api";
+
+// isSameHost is the security gate that decides whether a user/LLM-supplied
+// shortLink receives credentials. Lock its behavior down — a wrong `true` leaks
+// X-MG-UserAccessToken (and custom gateway auth) to an attacker-controlled host.
+
+test("isSameHost: same host, different path -> true", () => {
+  assert.equal(isSameHost("https://a.com/goto/x", "https://a.com"), true);
+});
+
+test("isSameHost: different host -> false (the core attack case)", () => {
+  assert.equal(isSameHost("https://evil.com/goto/x", "https://a.com"), false);
+});
+
+test("isSameHost: protocol differs, host same -> true", () => {
+  assert.equal(isSameHost("http://a.com/goto/x", "https://a.com"), true);
+});
+
+test("isSameHost: port mismatch -> false", () => {
+  assert.equal(isSameHost("https://a.com:8080/goto/x", "https://a.com"), false);
+});
+
+test("isSameHost: same host with explicit matching port -> true", () => {
+  assert.equal(isSameHost("https://a.com:8080/goto/x", "https://a.com:8080"), true);
+});
+
+test("isSameHost: subdomain is a different host -> false", () => {
+  assert.equal(isSameHost("https://cdn.a.com/goto/x", "https://a.com"), false);
+});
+
+test("isSameHost: invalid input returns false, never throws", () => {
+  assert.equal(isSameHost("not-a-url", "https://a.com"), false);
+  assert.equal(isSameHost("https://a.com", "not-a-url"), false);
+  assert.equal(isSameHost("", ""), false);
+});


### PR DESCRIPTION
## Summary

Support custom HTTP headers for private-deploy gateways (issue #64), security hardening on top of that feature, `sourceLayerId` support across all design-data tools (fixes first-call rejection), and a full dependency audit that takes vulnerabilities **14 → 0**.

## 1. Custom headers (issue #64)

- Robust `--header "Key: Value"` parsing — warns on missing value / missing `:` / flag-swallowing instead of failing silently
- `MG_EXTRA_HEADERS` env var (JSON object) so secrets aren't exposed in `process.argv` (visible via `ps`)
- `getEffectiveHeaders()` merges env + CLI (CLI wins); `maskSensitiveHeaders()` redacts credentials in debug output

## 2. Security hardening

- **`redactForWarn`**: warning output no longer echoes sensitive raw header values (e.g. a mistyped `Authorization Bearer eyJ…` with no `:` separator)
- **Short-link credential gate (`isSameHost`)**: `extractIdsFromUrl` now sends `X-MG-UserAccessToken` + custom headers only when the short-link host matches the configured API host. Prevents token leakage to an arbitrary URL via prompt injection (`https://evil.com/goto/x`). Same-host links (the normal private-deploy case) still pass the internal gateway.
- `getEffectiveHeaders` / `getCommonHeader` / `getBaseUrl` memoized on the per-request hot path

## 3. `sourceLayerId` support across all design-data tools

All five design-data tools now accept `sourceLayerId` as an alternative to `layerId` (from the URL `source_layer_id` param). Previously, calls with only `{fileId, sourceLayerId}` were **rejected on the first attempt** because the validation required `layerId` — even though `effectiveLayerId = sourceLayerId || layerId` already resolves the effective layer. This forced the LLM to always retry, wasting a round-trip.

- `extractSvg`: added `sourceLayerId` to the client schema (server already had it).
- `getDesignSections` / `getDsl` / `getDesignTexts` / `getDesignSvgs`: relaxed validation from `!layerId` to `(!layerId && !sourceLayerId)`; compute `effectiveLayerId` with a guard that narrows it to `string` for downstream.
- Error messages now mention `sourceLayerId` as a valid alternative.
- Dual-project sync: corresponding `sourceLayerId` schema + gate changes applied to `frontend-mcp-server` in a companion branch.

## 4. Dependency audit (14 → 0 vulnerabilities)

- `axios` 1.6.0 → 1.18.1 (CVE-2024-39338 SSRF + others)
- Removed unused `pkg` devDep (deprecated, No fix available)
- `@typescript-eslint` 6 → 8, `eslint` 8.57 (minimatch ReDoS chain)
- `js-yaml` ^4.1.0 → ^4.2.0 (DoS)
- `overrides`: `hono` / `form-data` / `fast-uri` / `ip-address` / `qs` forced to safe versions (transitive deps of `@modelcontextprotocol/sdk` and `axios` — not fixable by upgrading the direct dependency)

## Test plan

- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors
- `npm test`: 47/47 (headers + url-safety + format suites)
- `npm run build`: success
- `npm audit`: 0 vulnerabilities

## Note

One harmless `EBADENGINE` warning remains: `eslint-visitor-keys@5.0.1` (a transitive dep of typescript-eslint 8) declares `node ^20.19.0`; verified lint runs correctly on 20.18.1. Dev-only, does not affect runtime / build / published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)