### PR TITLE
feat(changelog): 基于 GitHub Releases 自动生成 CHANGELOG 并集成发版 CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,3 +115,26 @@ jobs:
           git tag v${{ steps.get-version.outputs.version }}
           git push
           git push --tags
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          ARGS=(--generate-notes --verify-tag --title "v$VERSION")
+          # beta / alpha 预发布版本标记为 prerelease
+          if [[ "$VERSION" == *beta* || "$VERSION" == *alpha* ]]; then
+            ARGS+=(--prerelease)
+          fi
+          gh release create "v$VERSION" "${ARGS[@]}"
+
+      - name: Update CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/generate-changelog.sh
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): update for v${{ steps.get-version.outputs.version }}" || echo "no changelog changes"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,275 @@
+# Changelog
+
+> 本文件由 GitHub Releases 自动生成，请勿手动编辑；发版后由 CI（.github/workflows/publish.yml）自动更新。
+
+## v0.2.1 (2026-07-01)
+
+## What's Changed
+* feat(getDesignSections): enforce absolute positioning via per-section bbox and rootContainer by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/98
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.2.0...v0.2.1
+
+
+## v0.2.0 (2026-07-01)
+
+## What's Changed
+* fix: replace colons in layer ids when generating image urls by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/95
+* Add npm source and issue metadata by @wowsofine in https://github.com/mastergo-design/mastergo-magic-mcp/pull/96
+* feat: add getDesignSvgs API and supporting tooling by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/87
+
+## New Contributors
+* @wowsofine made their first contribution in https://github.com/mastergo-design/mastergo-magic-mcp/pull/96
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.8...v0.2.0
+
+
+### v0.1.9-alpha.0 (2026-07-01)
+
+## What's Changed
+* fix: replace colons in layer ids when generating image urls by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/95
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.8...v0.1.9-alpha.0
+
+
+## v0.1.8 (2026-07-01)
+
+## What's Changed
+* fix: add prepare script for GitHub install by @lewis617 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/92
+* refactor(proxy): use axios built-in proxy support, drop https-proxy-agent by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/93
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.7...v0.1.8
+
+
+### v0.1.7-beta.0 (2026-07-01)
+
+## What's Changed
+* feat(tools): add support for source_layer_id parameter in API calls by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/84
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.6-beta.4...v0.1.7-beta.0
+
+
+## v0.1.7 (2026-07-01)
+
+## What's Changed
+* feat(tools): add support for source_layer_id parameter in API calls by @muzi131313 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/84
+* feat: add --proxy CLI argument support by @lewis617 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/91
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.6...v0.1.7
+
+
+### v0.1.6-beta.4 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.6-beta.3...v0.1.6-beta.4
+
+
+### v0.1.6-beta.3 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.6-beta.2...v0.1.6-beta.3
+
+
+### v0.1.6-beta.2 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.6-beta.1...v0.1.6-beta.2
+
+
+### v0.1.6-beta.1 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.6-beta.0...v0.1.6-beta.1
+
+
+### v0.1.6-beta.0 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.5...v0.1.6-beta.0
+
+
+## v0.1.6 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.5...v0.1.6
+
+
+## v0.1.5 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.4...v0.1.5
+
+
+## v0.1.4 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.2...v0.1.4
+
+
+## v0.1.2 (2026-07-01)
+
+## What's Changed
+* fix: ssl error by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/56
+* docs: update README and README.zh-CN to reflect new entry point for l… by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/57
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.1...v0.1.2
+
+
+## v0.1.1 (2026-07-01)
+
+## What's Changed
+* feat: url parser improvement by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/49
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.1.0...v0.1.1
+
+
+## v0.1.0 (2026-07-01)
+
+## What's Changed
+* refactor: remove bin directory and CLI script, update build process t… by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/46
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.6...v0.1.0
+
+
+### v0.0.7-beta.0 (2026-07-01)
+
+## What's Changed
+* refactor: remove bin directory and CLI script, update build process t… by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/46
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.6...v0.0.7-beta.0
+
+
+## v0.0.6 (2026-07-01)
+
+## What's Changed
+* fix: update short link description in GetDslTool by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/44
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.5...v0.0.6
+
+
+## v0.0.5 (2026-07-01)
+
+## What's Changed
+* feat: support short link by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/42
+* fix: description by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/43
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4...v0.0.5
+
+
+### v0.0.4-beta.11 (2026-07-01)
+
+## What's Changed
+* feature:增加env配置token选项 by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/27
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.10...v0.0.4-beta.11
+
+
+### v0.0.4-beta.10 (2026-07-01)
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.9...v0.0.4-beta.10
+
+
+### v0.0.4-beta.9 (2026-07-01)
+
+## What's Changed
+* feat: update Readme by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/21
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.8...v0.0.4-beta.9
+
+
+### v0.0.4-beta.8 (2026-07-01)
+
+## What's Changed
+* feat: generator handle svg by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/20
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.7...v0.0.4-beta.8
+
+
+### v0.0.4-beta.7 (2026-07-01)
+
+## What's Changed
+* update readme & add version by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/15
+* feat: component set -> vue component by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/17
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.6...v0.0.4-beta.7
+
+
+### v0.0.4-beta.6 (2026-07-01)
+
+## What's Changed
+* update meta.md by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/14
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.5...v0.0.4-beta.6
+
+
+### v0.0.4-beta.5 (2026-07-01)
+
+## What's Changed
+* feature:增加meta能力 by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/13
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.4...v0.0.4-beta.5
+
+
+### v0.0.4-beta.4 (2026-07-01)
+
+## What's Changed
+* fix: improve error handling in GetDslTool by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/12
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.3...v0.0.4-beta.4
+
+
+### v0.0.4-beta.3 (2026-07-01)
+
+## What's Changed
+* feat: --rule args by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/5
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/compare/v0.0.4-beta.2...v0.0.4-beta.3
+
+
+### v0.0.4-beta.2 (2026-07-01)
+
+## What's Changed
+* feat: getComponentLink by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/2
+* feat: CICD by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/3
+* fix: cd error by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/4
+
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/commits/v0.0.4-beta.2
+
+
+## v0.0.4 (2026-07-01)
+
+## What's Changed
+* feat: getComponentLink by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/2
+* feat: CICD by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/3
+* fix: cd error by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/4
+* feat: --rule args by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/5
+* fix: improve error handling in GetDslTool by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/12
+* feature:增加meta能力 by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/13
+* update meta.md by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/14
+* update readme & add version by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/15
+* feat: component set -> vue component by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/17
+* feat: generator handle svg by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/20
+* feat: update Readme by @Seann0824 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/21
+* feature:增加env配置token选项 by @yansanmu90 in https://github.com/mastergo-design/mastergo-magic-mcp/pull/27
+* Deployment: Dockerfile and Smithery config by @calclavia in https://github.com/mastergo-design/mastergo-magic-mcp/pull/30
+* fix: tool命名兼容augment by @Luc-xz in https://github.com/mastergo-design/mastergo-magic-mcp/pull/36
+
+## New Contributors
+* @yansanmu90 made their first contribution in https://github.com/mastergo-design/mastergo-magic-mcp/pull/13
+* @calclavia made their first contribution in https://github.com/mastergo-design/mastergo-magic-mcp/pull/30
+* @Luc-xz made their first contribution in https://github.com/mastergo-design/mastergo-magic-mcp/pull/36
+
+**Full Changelog**: https://github.com/mastergo-design/mastergo-magic-mcp/commits/v0.0.4
+
+

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# 从 GitHub Releases 自动生成 CHANGELOG.md
+# 由 CI（.github/workflows/publish.yml）发版后调用，也可本地手动执行：bash scripts/generate-changelog.sh
+# 依赖：gh CLI 已登录且对仓库有读权限
+set -euo pipefail
+
+OUT="${1:-CHANGELOG.md}"
+
+{
+  echo "# Changelog"
+  echo ""
+  echo "> 本文件由 GitHub Releases 自动生成，请勿手动编辑；发版后由 CI（.github/workflows/publish.yml）自动更新。"
+  echo ""
+  # 1. 先拉 release 列表（含发布顺序与 prerelease 标记），list 不返回 body
+  # 2. 再逐个 view 取 body，组装成 Keep-a-Changelog 风格
+  gh release list --limit 200 --json tagName,publishedAt,isPrerelease --jq \
+    '. | sort_by(.publishedAt) | reverse | .[] | "\(.tagName)\t\(.publishedAt)\t\(.isPrerelease)"' \
+  | while IFS=$'\t' read -r tag pub pre; do
+      [ -z "$tag" ] && continue
+      body=$(gh release view "$tag" --json body --jq '.body // "_no notes_"')
+      # 正式版用二级标题，预发布用三级标题以示区分
+      if [ "$pre" = "true" ]; then hdr="###"; else hdr="##"; fi
+      printf '%s %s (%s)\n\n' "$hdr" "$tag" "${pub:0:10}"
+      printf '%s\n\n\n' "$body"
+    done
+} > "$OUT"
+
+echo "✓ CHANGELOG 已生成：${OUT}（$(wc -l < "${OUT}") 行）"


### PR DESCRIPTION
## 背景

项目此前只有 git tag，无 GitHub Release、无 CHANGELOG。本 PR 让 changelog 完全基于 GitHub Releases 自动生成，发版流程零额外手动维护。

## 变更内容

### 1. 自动生成脚本 `scripts/generate-changelog.sh`
- 从 GitHub Releases 拉取 body，组装成 Keep-a-Changelog 风格的 `CHANGELOG.md`
- 正式版用 `##`，预发布（beta/alpha）用 `###` 区分
- CI 与本地共用同一脚本，避免逻辑漂移

### 2. 初始 `CHANGELOG.md`
- 一次性补齐 **v0.0.4 → v0.2.1 共 31 个历史版本**

### 3. 发版 CI 集成 `.github/workflows/publish.yml`
在原有「npm version → publish → 打 tag → push」之后追加两步：

| 步骤 | 作用 |
|------|------|
| **Create GitHub Release** | `gh release create --generate-notes`，GitHub 按 PR/commit 自动生成 notes；beta/alpha 自动标 prerelease |
| **Update CHANGELOG.md** | 调用共享脚本重新生成并提交回 main |

### 4. 历史 Release 补齐
GitHub 上 31 个历史 tag 的 Release 已全部创建完成（含 PR 标题、作者、compare diff 链接）。

## 验证
- ✅ `scripts/generate-changelog.sh` 本地运行退出码 0，生成 275 行
- ✅ `publish.yml` YAML 语法校验通过
- ✅ 后续发版触发 `workflow_dispatch` 即可自动产出 Release + CHANGELOG

## 后续流程
合并到 main 后，发版时只需在 Actions 页手动触发 **Publish to NPM** workflow 选 release-type，Release 与 CHANGELOG.md 会自动更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
