### PR TITLE
fix: report actual package version in McpServer serverInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { GetDesignTextsTool } from "./tools/get-design-texts";
 import { ExtractSvgTool } from "./tools/extract-svg";
 import { parserArgs, getEffectiveHeaders, maskSensitiveHeaders } from "./utils/args";
 import { normalizeFormat } from "./utils/format";
+import packageJson from "../package.json";
 
 const SERVER_INSTRUCTIONS = `
 ## MasterGo Design DSL - Section-by-Section Workflow
@@ -118,7 +119,7 @@ function main() {
   const server = new McpServer(
     {
       name: "MasterGoMcpServer",
-      version: "0.0.1",
+      version: packageJson.version,
     },
     { instructions: SERVER_INSTRUCTIONS }
   );


### PR DESCRIPTION
## 背景

Fixes #108

`McpServer` 构造函数硬编码了 `version: "0.0.1"`,而 `package.json` 声明的是 `0.2.2`。MCP 客户端在 `initialize` 响应的 `serverInfo.version` 中收到的是错误版本,用户报 bug 时无法据此识别所用发布版本。

`src/tools/get-version.ts` 已经正确地从 `package.json` 读取版本,只有 `index.ts` 例外。

## 改动

- `src/index.ts`:新增 `import packageJson from "../package.json";`
- `src/index.ts`:`version: "0.0.1"` → `version: packageJson.version`

与 `get-version.ts` 的做法保持一致,后续发版自动跟随,无需手动同步。

## 验证

`npm run build` 通过,构建产物 `dist/index.js` 中注入的是 `version:"0.2.2"`,硬编码 `"0.0.1"` 出现次数为 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)