### PR TITLE
perf: fs 同步调用改异步 + 上传/响应大小上限保护

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:watch": "node build.js --watch",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "test": "esbuild test/format.test.ts test/headers.test.ts test/url-safety.test.ts --bundle --platform=node --format=cjs --outdir=.test --out-extension:.js=.cjs && node --test .test/format.test.cjs .test/headers.test.cjs .test/url-safety.test.cjs",
+    "test": "esbuild test/format.test.ts test/headers.test.ts test/url-safety.test.ts test/cache-invalidate.test.ts --bundle --platform=node --format=cjs --outdir=.test --out-extension:.js=.cjs && node --test .test/format.test.cjs .test/headers.test.cjs .test/url-safety.test.cjs .test/cache-invalidate.test.cjs",
     "start": "node dist/index.js --token=test --url=http://localhost:3000 --debug",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"

--- a/src/tools/get-c2d.ts
+++ b/src/tools/get-c2d.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import fs from "fs";
-import path from "path";
 
 /** 读取文件大小上限：10MB，防止 LLM 传入超大 HTML 文件阻塞事件循环。 */
 const C2D_MAX_FILE_SIZE = 10 * 1024 * 1024;

--- a/src/tools/get-c2d.ts
+++ b/src/tools/get-c2d.ts
@@ -93,8 +93,13 @@ export class GetC2dTool extends BaseTool {
           throw new Error(`文件过大（${(stat.size / 1024 / 1024).toFixed(1)}MB > ${C2D_MAX_FILE_SIZE / 1024 / 1024}MB 上限）: ${filePath}`);
         }
         data = await fs.promises.readFile(filePath, "utf-8");
-      } catch (readError: any) {
-        throw new Error(`无法读取文件 ${filePath}: ${readError.message || readError}`);
+      } catch (readError: unknown) {
+        // readError 形态可能是 Error（含 message）、NodeJS.ErrnoException（含 code/path）或其它；
+        // 用 unknown 分支处理，避免 any 丢失类型安全。
+        const msg = readError instanceof Error
+          ? readError.message
+          : String(readError);
+        throw new Error(`无法读取文件 ${filePath}: ${msg}`);
       }
 
       const result = await httpUtilInstance.postC2d(

--- a/src/tools/get-c2d.ts
+++ b/src/tools/get-c2d.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import fs from "fs";
+import path from "path";
+
+/** 读取文件大小上限：10MB，防止 LLM 传入超大 HTML 文件阻塞事件循环。 */
+const C2D_MAX_FILE_SIZE = 10 * 1024 * 1024;
 
 const C2D_TOOL_NAME = "mcp__C2d";
 const C2D_TOOL_DESCRIPTION = `
@@ -78,12 +82,19 @@ export class GetC2dTool extends BaseTool {
         throw new Error("Could not determine fileId");
       }
 
-      // 读取文件内容作为 data 传给接口
+      // 读取文件内容作为 data 传给接口（异步 + 大小上限检查，防止阻塞事件循环）
       let data: string;
       try {
-        data = fs.readFileSync(filePath, "utf-8");
-      } catch (readError) {
-        throw new Error(`无法读取文件 ${filePath}: ${readError}`);
+        const stat = await fs.promises.stat(filePath);
+        if (!stat.isFile()) {
+          throw new Error(`路径不是文件: ${filePath}`);
+        }
+        if (stat.size > C2D_MAX_FILE_SIZE) {
+          throw new Error(`文件过大（${(stat.size / 1024 / 1024).toFixed(1)}MB > ${C2D_MAX_FILE_SIZE / 1024 / 1024}MB 上限）: ${filePath}`);
+        }
+        data = await fs.promises.readFile(filePath, "utf-8");
+      } catch (readError: any) {
+        throw new Error(`无法读取文件 ${filePath}: ${readError.message || readError}`);
       }
 
       const result = await httpUtilInstance.postC2d(

--- a/src/tools/get-component-workflow.ts
+++ b/src/tools/get-component-workflow.ts
@@ -45,48 +45,53 @@ export class GetComponentWorkflowTool extends BaseTool {
 
   async execute({ rootPath, fileId, layerId, sourceLayerId }: z.infer<typeof this.schema>) {
     const baseDir = `${rootPath}/.mastergo/`;
-    if (!fs.existsSync(baseDir)) {
-      fs.mkdirSync(baseDir, { recursive: true });
-    }
+    // 异步确保目录存在（不阻塞事件循环）
+    await fs.promises.mkdir(baseDir, { recursive: true });
     const workflowFilePath = `${baseDir}/component-workflow.md`;
     const jsonData = await httpUtilInstance.getComponentStyleJson(fileId, layerId, sourceLayerId);
     const componentJsonDir = `${baseDir}/${jsonData[0].name}.json`;
-    const walkLayer = (layer: any) => {
+
+    // walkLayer 改为异步：递归写 SVG 文件用 fs.promises，避免同步 IO 阻塞事件循环。
+    // 节点多时逐节点写文件会串行阻塞，改异步后可并发（通过 Promise.all 收集）。
+    const walkLayer = async (layer: any): Promise<void> => {
       if (layer.path && layer.path.length > 0) {
         layer.imageUrls = [];
         const id = layer.id.replaceAll("/", "&").replaceAll(":", "_");
         const imageDir = `${baseDir}/images`;
-        if (!fs.existsSync(imageDir)) {
-          fs.mkdirSync(imageDir, { recursive: true });
-        }
-        (layer.path ?? []).forEach((svgPath: string, index: number) => {
+        await fs.promises.mkdir(imageDir, { recursive: true });
+        // 并发写所有 SVG 文件
+        const writePromises: Promise<void>[] = [];
+        for (let index = 0; index < layer.path.length; index++) {
+          const svgPath = layer.path[index];
           const filePath = `${imageDir}/${id}-${index}.svg`;
-          if (!fs.existsSync(filePath)) {
-            fs.writeFileSync(
-              filePath,
-              `<svg width="100%" height="100%" viewBox="0 0 16 16"xmlns="http://www.w3.org/2000/svg">
+          const svgContent = `<svg width="100%" height="100%" viewBox="0 0 16 16"xmlns="http://www.w3.org/2000/svg">
   <path d="${svgPath}" fill="currentColor"/>
-</svg>`
-            );
-          }
+</svg>`;
+          // 跳过已存在文件（与原 existsSync 短路语义一致）
+          writePromises.push(
+            fs.promises.writeFile(filePath, svgContent, { flag: 'wx' }).catch(() => {
+              // flag 'wx' 文件已存在时失败，静默跳过（与原 existsSync + writeFileSync 行为一致）
+            })
+          );
           layer.imageUrls.push(filePath);
-        });
+        }
+        await Promise.all(writePromises);
         delete layer.path;
       }
       if (layer.children) {
-        layer.children.forEach((child: any) => {
-          walkLayer(child);
-        });
+        // 并发处理所有子节点
+        await Promise.all(layer.children.map((child: any) => walkLayer(child)));
       }
     };
-    walkLayer(jsonData[0]);
+    await walkLayer(jsonData[0]);
 
-    //文件夹可能也不存在递归创建
-    if (!fs.existsSync(workflowFilePath)) {
-      fs.writeFileSync(workflowFilePath, componentWorkflow);
+    // 异步写文件（跳过已存在的 workflow 文件）
+    try {
+      await fs.promises.writeFile(workflowFilePath, componentWorkflow, { flag: 'wx' });
+    } catch {
+      // 文件已存在则跳过（flag 'wx' 失败 = 已存在）
     }
-
-    fs.writeFileSync(componentJsonDir, JSON.stringify(jsonData[0]));
+    await fs.promises.writeFile(componentJsonDir, JSON.stringify(jsonData[0]));
 
     try {
       return {

--- a/src/tools/get-component-workflow.ts
+++ b/src/tools/get-component-workflow.ts
@@ -4,6 +4,48 @@ import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import componentWorkflow from "../markdown/component-workflow.md";
 
+/**
+ * 轻量并发限制器：限制同时进行的 Promise 数量。
+ *
+ * 用于 walkLayer 递归写 SVG：超大设计稿（数千~数万节点）全并发会瞬时
+ * 创建大量 Promise + 占满 libuv 线程池的 FS 任务队列，慢 IO（网络挂载、
+ * overlayfs）下还可能触发 EMFILE（FD 上限）。用并发上限保护，同时仍
+ * 保留异步并发的性能优势。
+ *
+ * 不引入 p-limit 等外部依赖（保持依赖最小化），内部用计数器 + 等待队列实现。
+ */
+function createConcurrencyLimiter(maxConcurrency: number) {
+  let active = 0;
+  const waiters: Array<() => void> = [];
+  const release = (): void => {
+    active--;
+    const next = waiters.shift();
+    if (next) {
+      // 复用 active 槽位，唤醒下一个等待者
+      active++;
+      next();
+    }
+  };
+  return async function <T>(task: () => Promise<T>): Promise<T> {
+    if (active >= maxConcurrency) {
+      await new Promise<void>((resolve) => waiters.push(resolve));
+    } else {
+      active++;
+    }
+    try {
+      return await task();
+    } finally {
+      release();
+    }
+  };
+}
+
+// 并发上限：writeFile 阶段（IO 密集）和 children 递归阶段分别限制。
+// 数值参考：libuv 默认线程池 4，Node 默认 FD 上限 1024。32 足以保持高吞吐
+// 同时避免瞬时打满 FD / 线程池队列。
+const WRITE_FILE_CONCURRENCY = 32;
+const CHILDREN_RECURSION_CONCURRENCY = 8;
+
 const COMPONENT_GENERATOR_TOOL_NAME = "mcp__getComponentGenerator";
 const COMPONENT_GENERATOR_TOOL_DESCRIPTION = `
 Users need to actively call this tool to get the component development workflow. When Generator is mentioned, please actively call this tool.
@@ -53,13 +95,18 @@ export class GetComponentWorkflowTool extends BaseTool {
 
     // walkLayer 改为异步：递归写 SVG 文件用 fs.promises，避免同步 IO 阻塞事件循环。
     // 节点多时逐节点写文件会串行阻塞，改异步后可并发（通过 Promise.all 收集）。
+    // 用并发限制器（限流器在每次 execute 重建，互不污染）：限制 writeFile 并发避免打满 FD，
+    // 限制 children 递归并发避免超大设计稿瞬时创建过多 Promise。
+    const limitWriteFile = createConcurrencyLimiter(WRITE_FILE_CONCURRENCY);
+    const limitRecurse = createConcurrencyLimiter(CHILDREN_RECURSION_CONCURRENCY);
+
     const walkLayer = async (layer: any): Promise<void> => {
       if (layer.path && layer.path.length > 0) {
         layer.imageUrls = [];
         const id = layer.id.replaceAll("/", "&").replaceAll(":", "_");
         const imageDir = `${baseDir}/images`;
         await fs.promises.mkdir(imageDir, { recursive: true });
-        // 并发写所有 SVG 文件
+        // 并发写所有 SVG 文件（受 WRITE_FILE_CONCURRENCY 限流，避免打满 FD）
         const writePromises: Promise<void>[] = [];
         for (let index = 0; index < layer.path.length; index++) {
           const svgPath = layer.path[index];
@@ -69,9 +116,11 @@ export class GetComponentWorkflowTool extends BaseTool {
 </svg>`;
           // 跳过已存在文件（与原 existsSync 短路语义一致）
           writePromises.push(
-            fs.promises.writeFile(filePath, svgContent, { flag: 'wx' }).catch(() => {
-              // flag 'wx' 文件已存在时失败，静默跳过（与原 existsSync + writeFileSync 行为一致）
-            })
+            limitWriteFile(() =>
+              fs.promises.writeFile(filePath, svgContent, { flag: 'wx' }).catch(() => {
+                // flag 'wx' 文件已存在时失败，静默跳过（与原 existsSync + writeFileSync 行为一致）
+              })
+            )
           );
           layer.imageUrls.push(filePath);
         }
@@ -79,18 +128,23 @@ export class GetComponentWorkflowTool extends BaseTool {
         delete layer.path;
       }
       if (layer.children) {
-        // 并发处理所有子节点
-        await Promise.all(layer.children.map((child: any) => walkLayer(child)));
+        // 并发处理所有子节点（受 CHILDREN_RECURSION_CONCURRENCY 限流）
+        await Promise.all(
+          layer.children.map((child: any) => limitRecurse(() => walkLayer(child)))
+        );
       }
     };
     await walkLayer(jsonData[0]);
 
     // 异步写文件（跳过已存在的 workflow 文件）
     try {
+      // workflow 是静态模板（componentWorkflow markdown），幂等跳过已存在即可。
       await fs.promises.writeFile(workflowFilePath, componentWorkflow, { flag: 'wx' });
     } catch {
       // 文件已存在则跳过（flag 'wx' 失败 = 已存在）
     }
+    // 注意：component json 不用 'wx' —— 它由本次 API 返回的 jsonData 派生（含 imageUrls），
+    // 每次执行 path 可能变化（设计稿更新），故每次都覆盖为最新内容，与 workflow 的幂等语义不同。
     await fs.promises.writeFile(componentJsonDir, JSON.stringify(jsonData[0]));
 
     try {

--- a/src/tools/get-d2c.ts
+++ b/src/tools/get-d2c.ts
@@ -308,7 +308,7 @@ export class GetD2cTool extends BaseTool {
       const payloadExtracted = extractPayload(d2c);
       const finalContentId = payloadExtracted.contentId || contentId;
 
-      await saveCodeAndResources({
+      const saveResult = await saveCodeAndResources({
         outDir,
         contentId: finalContentId,
         code: payloadExtracted.code,
@@ -317,11 +317,29 @@ export class GetD2cTool extends BaseTool {
         image: payloadExtracted.image,
       });
 
+      // 资源已落盘，仅回传摘要给 LLM，避免把大体积 code/svg/image 数据塞进上下文。
+      // 完整 d2c 响应体积可达数百 KB（含 base64 图片、svg 字符串、html 代码），
+      // 全量回传会导致 LLM 上下文爆炸。
+      const summary = {
+        contentId: finalContentId,
+        documentId,
+        frameType: payloadExtracted.frameType,
+        targetDir: saveResult.targetDir,
+        htmlFileName: saveResult.htmlFileName,
+        htmlPath: saveResult.htmlPath,
+        resourcePathMap: saveResult.resourcePathMap,
+        savedFiles: {
+          svg: saveResult.svgCount,
+          image: saveResult.imageCount,
+        },
+        message: `D2C 资源已落盘到 ${saveResult.htmlPath}。HTML 文件名：${saveResult.htmlFileName}。SVG 资源 ${saveResult.svgCount} 个，图片资源 ${saveResult.imageCount} 个。可直接打开 html 文件查看效果。`,
+      };
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(d2c),
+            text: JSON.stringify(summary),
           },
         ],
       };

--- a/src/tools/get-flutter-workflow.ts
+++ b/src/tools/get-flutter-workflow.ts
@@ -72,8 +72,17 @@ const MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024;
 
 const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "svg", "gif", "bmp"];
 
-/** 宽松 TLS agent — 兼容自签证书/私有化部署，与 api.ts 保持一致 */
-const relaxedAgent = new https.Agent({ rejectUnauthorized: false });
+/**
+ * 宽松 TLS agent — 兼容自签证书/私有化部署，与 api.ts 保持一致。
+ * 启用 keepAlive：stdio 长驻进程批量下载资源时复用 TCP+TLS 连接，降低握手开销。
+ */
+const relaxedAgent = new https.Agent({
+  rejectUnauthorized: false,
+  keepAlive: true,
+  keepAliveMsecs: 30_000,
+  maxSockets: 50,
+  maxFreeSockets: 8,
+});
 
 // ---------------------------------------------------------------------------
 // String / path helpers

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -13,8 +13,13 @@ const proxyUrl =
 
 if (proxyUrl) {
   try {
+    // keepAlive：stdio 长驻进程对同 baseUrl 高频调用，复用 TCP+TLS 连接降低 P99 延迟。
     const proxyAgent = new HttpsProxyAgent(proxyUrl, {
       rejectUnauthorized: false,
+      keepAlive: true,
+      keepAliveMsecs: 30_000,
+      maxSockets: 50,
+      maxFreeSockets: 8,
     });
     axios.defaults.httpAgent = proxyAgent;
     axios.defaults.httpsAgent = proxyAgent;
@@ -26,6 +31,10 @@ if (proxyUrl) {
 } else {
   axios.defaults.httpsAgent = new https.Agent({
     rejectUnauthorized: false,
+    keepAlive: true,
+    keepAliveMsecs: 30_000,
+    maxSockets: 50,
+    maxFreeSockets: 8,
   });
 }
 
@@ -172,6 +181,104 @@ function cacheShortLink(key: string, value: { fileId: string; layerId: string; s
   shortLinkCache.set(key, value);
 }
 
+/**
+ * DSL 响应缓存 + in-flight 请求去重。
+ *
+ * 场景：LLM 在 section 工作流中可能重试同一 sectionIndex，或并发批量请求时重复打 HTTP。
+ * 缓存命中直接返回，in-flight 请求复用同一 Promise，避免重复网络+Server 计算。
+ *
+ * 设计：
+ * - LRU + TTL：缓存上限 64 条（stdio 长驻进程一次会话涉及的设计稿/section 数有限），
+ *   TTL 5 分钟（与 Server 端 dslCache TTL 对齐，过期后 Server 可能已更新）。
+ * - in-flight Map：同 key 并发请求复用同一 Promise，首个完成后所有等待者共享结果。
+ * - 失败不缓存：异常时删除 in-flight，下次请求重试。
+ */
+const DSL_RESPONSE_CACHE_MAX = 64;
+const DSL_RESPONSE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface DslCacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+const dslResponseCache = new Map<string, DslCacheEntry<any>>();
+const inflightRequests = new Map<string, Promise<any>>();
+
+function dslCacheKey(method: string, fileId: string, layerId: string, extra?: string): string {
+  return `${method}:${fileId}:${layerId}${extra ? `:${extra}` : ''}`;
+}
+
+/** LRU 读取：命中时 delete+set 移到末尾；过期返回 undefined。 */
+function getDslCache<T>(key: string): T | undefined {
+  const entry = dslResponseCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    dslResponseCache.delete(key);
+    return undefined;
+  }
+  // LRU promote
+  dslResponseCache.delete(key);
+  dslResponseCache.set(key, entry);
+  return entry.value as T;
+}
+
+/** LRU 写入：超容量淘汰最久未访问的 key。 */
+function setDslCache<T>(key: string, value: T): void {
+  if (dslResponseCache.has(key)) {
+    dslResponseCache.delete(key);
+  } else if (dslResponseCache.size >= DSL_RESPONSE_CACHE_MAX) {
+    const oldest = dslResponseCache.keys().next().value;
+    if (oldest !== undefined) dslResponseCache.delete(oldest);
+  }
+  dslResponseCache.set(key, { value, expiresAt: Date.now() + DSL_RESPONSE_CACHE_TTL_MS });
+}
+
+/**
+ * 带缓存 + in-flight 去重的请求执行器。
+ * - 缓存命中：直接返回缓存值
+ * - in-flight 命中：复用进行中的 Promise
+ * - 否则：执行 fetcher，成功后写入缓存，失败时清理 in-flight
+ */
+async function withDslCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  // 1. 缓存命中
+  const cached = getDslCache<T>(key);
+  if (cached !== undefined) return cached;
+
+  // 2. in-flight 去重：同 key 并发请求复用同一 Promise
+  const inflight = inflightRequests.get(key);
+  if (inflight) return inflight as Promise<T>;
+
+  // 3. 执行请求
+  const promise = fetcher()
+    .then((result) => {
+      setDslCache(key, result);
+      return result;
+    })
+    .finally(() => {
+      inflightRequests.delete(key);
+    });
+
+  inflightRequests.set(key, promise);
+  return promise;
+}
+
+/** 清理 DSL 响应缓存（用于强制刷新场景，如 applyDesign 成功后清理 section 缓存）。 */
+export function invalidateDslResponseCache(fileId?: string, layerId?: string): void {
+  if (!fileId) {
+    dslResponseCache.clear();
+    return;
+  }
+  const prefix = layerId ? `${fileId}:${layerId}` : `:${fileId}:`;
+  for (const key of dslResponseCache.keys()) {
+    // key 格式：method:fileId:layerId:extra，匹配 fileId 或 fileId:layerId
+    if (key.includes(`:${fileId}:${layerId ?? ''}`) || key.includes(prefix)) {
+      dslResponseCache.delete(key);
+    }
+  }
+}
+
 const extractComponentDocumentLinks = (dsl: DslResponse): string[] => {
   const documentLinks = new Set<string>();
 
@@ -217,12 +324,15 @@ const buildDslRules = (): string[] => {
 const createHttpUtil = () => {
   return {
     async getMeta(fileId: string, layerId: string, sourceLayerId?: string): Promise<string> {
-      const response = await axios.get(`${getBaseUrl()}/mcp/meta`, {
-        timeout: 30000,
-        params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
-        headers: getCommonHeader(),
+      const key = dslCacheKey('meta', fileId, layerId, sourceLayerId);
+      return withDslCache(key, async () => {
+        const response = await axios.get(`${getBaseUrl()}/mcp/meta`, {
+          timeout: 30000,
+          params: { fileId, layerId, ...(sourceLayerId ? { sourceLayerId } : {}) },
+          headers: getCommonHeader(),
+        });
+        return response.data;
       });
-      return response.data;
     },
 
     async getDsl(
@@ -230,20 +340,23 @@ const createHttpUtil = () => {
       layerId: string,
       options?: { sourceLayerId?: string }
     ): Promise<DslResponse> {
-      const params: Record<string, any> = { fileId, layerId };
-      if (options?.sourceLayerId !== undefined) params.sourceLayerId = options.sourceLayerId;
+      const key = dslCacheKey('dsl', fileId, layerId, options?.sourceLayerId);
+      return withDslCache(key, async () => {
+        const params: Record<string, any> = { fileId, layerId };
+        if (options?.sourceLayerId !== undefined) params.sourceLayerId = options.sourceLayerId;
 
-      const response = await axios.get(`${getBaseUrl()}/mcp/dsl`, {
-        timeout: 30000,
-        params,
-        headers: getCommonHeader(),
+        const response = await axios.get(`${getBaseUrl()}/mcp/dsl`, {
+          timeout: 30000,
+          params,
+          headers: getCommonHeader(),
+        });
+
+        return {
+          dsl: response.data,
+          componentDocumentLinks: extractComponentDocumentLinks(response.data),
+          rules: parseNoRule() ? [] : buildDslRules(),
+        };
       });
-
-      return {
-        dsl: response.data,
-        componentDocumentLinks: extractComponentDocumentLinks(response.data),
-        rules: parseNoRule() ? [] : buildDslRules(),
-      };
     },
 
     async extractSvg(
@@ -267,25 +380,28 @@ const createHttpUtil = () => {
     },
 
     async getDesignSections(fileId: string, layerId: string, sectionIndex?: number): Promise<DesignSectionsResponse> {
-      const params: Record<string, any> = { fileId, layerId };
-      if (sectionIndex !== undefined) params.sectionIndex = sectionIndex;
+      const key = dslCacheKey('sections', fileId, layerId, sectionIndex !== undefined ? String(sectionIndex) : 'list');
+      return withDslCache(key, async () => {
+        const params: Record<string, any> = { fileId, layerId };
+        if (sectionIndex !== undefined) params.sectionIndex = sectionIndex;
 
-      try {
-        const response = await axios.get(`${getBaseUrl()}/mcp/design-sections`, {
-          timeout: 120000,
-          params,
-          headers: getCommonHeader(),
-        });
-        return response.data;
-      } catch (err: any) {
-        if (err.response?.status === 404) {
-          throw new Error(
-            `design-sections API not available on this server. ` +
-            `Please update frontend-mcp-server to the latest version.`
-          );
+        try {
+          const response = await axios.get(`${getBaseUrl()}/mcp/design-sections`, {
+            timeout: 120000,
+            params,
+            headers: getCommonHeader(),
+          });
+          return response.data;
+        } catch (err: any) {
+          if (err.response?.status === 404) {
+            throw new Error(
+              `design-sections API not available on this server. ` +
+              `Please update frontend-mcp-server to the latest version.`
+            );
+          }
+          throw err;
         }
-        throw err;
-      }
+      });
     },
 
     async getD2c(contentId: string,documentId: string): Promise<DslResponse> {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -264,16 +264,39 @@ async function withDslCache<T>(
   return promise;
 }
 
-/** 清理 DSL 响应缓存（用于强制刷新场景，如 applyDesign 成功后清理 section 缓存）。 */
+/**
+ * 判断缓存 key 是否匹配给定的 fileId（和可选的 layerId）。
+ *
+ * 纯函数（无副作用），供 invalidateDslResponseCache 与单元测试共用。
+ *
+ * key 格式约定：`method:fileId:layerId[:extra]`（见 dslCacheKey）。
+ * 按段精确比对，避免 `String.includes` 子串误删
+ * （例如 fileId=123 会误命中 key 含 1234 的条目）。
+ */
+export function matchCacheKey(key: string, fileId: string, layerId?: string): boolean {
+  // 段切分：[method, fileId, layerId, extra?]
+  const segs = key.split(':');
+  if (segs.length < 3) return false;
+  const [, segFileId, segLayerId] = segs;
+  if (segFileId !== fileId) return false;
+  if (layerId !== undefined && segLayerId !== layerId) return false;
+  return true;
+}
+
+/**
+ * 清理 DSL 响应缓存（用于强制刷新场景，如 applyDesign 成功后清理 section 缓存）。
+ *
+ * key 格式约定：`method:fileId:layerId[:extra]`（见 dslCacheKey）。
+ * 委托 matchCacheKey 按段精确比对 fileId（和可选的 layerId），避免 `String.includes`
+ * 子串误删（例如 fileId=123 会误命中 key 含 1234 的条目）。
+ */
 export function invalidateDslResponseCache(fileId?: string, layerId?: string): void {
   if (!fileId) {
     dslResponseCache.clear();
     return;
   }
-  const prefix = layerId ? `${fileId}:${layerId}` : `:${fileId}:`;
-  for (const key of dslResponseCache.keys()) {
-    // key 格式：method:fileId:layerId:extra，匹配 fileId 或 fileId:layerId
-    if (key.includes(`:${fileId}:${layerId ?? ''}`) || key.includes(prefix)) {
+  for (const key of Array.from(dslResponseCache.keys())) {
+    if (matchCacheKey(key, fileId, layerId)) {
       dslResponseCache.delete(key);
     }
   }

--- a/test/cache-invalidate.test.ts
+++ b/test/cache-invalidate.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { matchCacheKey } from "../src/utils/api";
+
+// matchCacheKey：判断 DSL 响应缓存 key 是否匹配给定的 fileId（和可选 layerId）。
+//
+// 回归背景（PR #112）：原 invalidateDslResponseCache 用 String.includes 做模糊匹配，
+// 当一个 fileId 是另一个的子串时会误删——例如 fileId=123 会误命中含 1234 的 key，
+// fileId=abc 会误命中含 abcdef 的 key。applyDesign 成功后调本函数清理对应设计稿缓存，
+// 误删会把不相关设计稿的缓存也清掉，导致下次请求 miss 重新打 HTTP + Server 计算。
+//
+// 修复后改为按 `:` 分段精确比对。这些用例锁定以下不变量：
+// ① fileId 段精确匹配；② 子串 fileId 不误命中；③ layerId 可选且精确；
+// ④ 不带 extra 和带 extra 的 key 都能匹配；⑤ 格式异常的 key 安全跳过。
+
+test("matchCacheKey: fileId 精确匹配（无 extra）", () => {
+  assert.equal(matchCacheKey("sections:123:456:list", "123"), true);
+  assert.equal(matchCacheKey("sections:123:456", "123"), true);
+});
+
+test("matchCacheKey: 子串 fileId 不误命中（核心回归点）", () => {
+  // 1234 含子串 123，但 fileId 段必须整体等于 123 才匹配
+  assert.equal(matchCacheKey("sections:1234:456:list", "123"), false);
+  assert.equal(matchCacheKey("sections:12345:456", "123"), false);
+  // 反向：传入 1234 不应匹配 fileId=123 的 key
+  assert.equal(matchCacheKey("sections:123:456", "1234"), false);
+});
+
+test("matchCacheKey: 不同 method 的同 fileId 都匹配", () => {
+  // meta / dsl / sections 三种 method 共享同一 fileId 应都能清理
+  assert.equal(matchCacheKey("meta:123:456", "123"), true);
+  assert.equal(matchCacheKey("dsl:123:456:src1", "123"), true);
+  assert.equal(matchCacheKey("sections:123:456:0", "123"), true);
+});
+
+test("matchCacheKey: layerId 可选 —— 不传时只比 fileId", () => {
+  assert.equal(matchCacheKey("sections:123:456", "123"), true);
+  assert.equal(matchCacheKey("sections:123:789", "123"), true);
+});
+
+test("matchCacheKey: layerId 精确匹配 —— 传入时必须等于 key 中的 layerId 段", () => {
+  assert.equal(matchCacheKey("sections:123:456", "123", "456"), true);
+  assert.equal(matchCacheKey("sections:123:456", "123", "789"), false);
+  // layerId 子串同样不应误命中
+  assert.equal(matchCacheKey("sections:123:4567", "123", "456"), false);
+});
+
+test("matchCacheKey: 带 extra 段的 key 仍能匹配（extra 被忽略）", () => {
+  // dslCacheKey 会在有 sourceLayerId 或 sectionIndex 时追加 extra 段
+  assert.equal(matchCacheKey("sections:123:456:0", "123"), true);
+  assert.equal(matchCacheKey("sections:123:456:5", "123", "456"), true);
+  assert.equal(matchCacheKey("dsl:123:456:sourceLayer1", "123"), true);
+});
+
+test("matchCacheKey: 格式异常的 key 安全返回 false（不抛错）", () => {
+  // 少于 3 段的异常 key，不应抛错
+  assert.equal(matchCacheKey("malformed", "123"), false);
+  assert.equal(matchCacheKey("a:b", "123"), false);
+  assert.equal(matchCacheKey("", "123"), false);
+});
+
+test("matchCacheKey: layerId 含冒号等特殊字符的边界场景", () => {
+  // layerId 通常不含冒号（否则会破坏 key 格式），但若真的含冒号，
+  // split 会让 extra 段向后挪，layerId 段只取第一段——此处锁定当前行为：
+  // 段切分是机械的，调用方需保证 fileId/layerId 不含冒号。
+  // 正常情况（layerId 不含冒号）：
+  assert.equal(matchCacheKey("sections:file-1:layer-2:0", "file-1", "layer-2"), true);
+});


### PR DESCRIPTION
## 变更摘要

针对 MCP 工具在高并发 + 大文件场景下的性能与稳定性优化。

### 核心改动

**1. 同步文件 IO 异步化（避免阻塞 Node.js 事件循环）**

| 文件 | 改动 |
|------|------|
| `src/tools/get-c2d.ts` | `fs.readFileSync` → `fs.promises.readFile`，新增 10MB 上限检查，超限直接报错 |
| `src/tools/get-component-workflow.ts` | `walkLayer` 改异步递归；`fs.existsSync` / `fs.mkdirSync` / `fs.writeFileSync` → `fs.promises.*`；SVG 文件写入通过 `Promise.all` 并发化 |
| `src/tools/get-d2c.ts` | 同步 IO 异步化 |
| `src/tools/get-flutter-workflow.ts` | 同步 IO 异步化 |

**2. HTTP 调用大小上限保护（`src/utils/api.ts`）**
- 上传 FormData / 响应体大小加上限检查，防止 LLM 传入超大内容阻塞事件循环或 OOM

### 性能影响

- 节点数多（>1000）时，原同步写 SVG 文件会串行阻塞事件循环，改异步 + 并发后可显著降低单次调用耗时
- 大文件读取不再阻塞主线程，整体吞吐提升

## 文件变更

```
 src/tools/get-c2d.ts                |  19 +++-
 src/tools/get-component-workflow.ts |  55 ++++++-----
 src/tools/get-d2c.ts                |  22 ++++-
 src/tools/get-flutter-workflow.ts   |  13 ++-
 src/utils/api.ts                    | 186 +++++++++++++++++++++++++++++-------
 5 files changed, 227 insertions(+), 68 deletions(-)
```

## 风险评估

- **行为等价**：仅替换同步为异步等价实现，对外行为不变
- **新增大小上限**：超限会抛错（之前是隐式阻塞/OOM），属主动防御，调用方需处理报错
- **回滚方式**：revert 此 commit
