### PR TITLE
feat: 新增 mcp__getPageLayers 客户端 tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,20 +21,24 @@ import packageJson from "../package.json";
 const SERVER_INSTRUCTIONS = `
 ## MasterGo Design DSL - Section-by-Section Workflow
 
-### Step -1: Multi-layer restoration — enumerate, then restore ONE layer at a time
-Use this workflow when the user wants to restore a WHOLE PAGE or a CONTAINER with multiple child layers (e.g. URL has \`page_id\`, or a top-level frame whose children should each be restored separately). Do NOT restore all layers in one shot — restore them sequentially.
+### Step -1: Multi-layer restoration — enumerate, then restore ONE layer at a time, EACH as its own file
+Use this workflow when the user wants to restore a WHOLE PAGE or a CONTAINER with multiple child layers (e.g. URL has \`page_id\`, or a top-level frame whose children should each be restored separately). Do NOT restore all layers in one shot — restore them sequentially, and **each layer MUST become its own standalone HTML file**.
 
 **Workflow:**
 1. **Enumerate**: Call \`mcp__getPageLayers\` with the page_id / parent layerId. It returns a flat list of ALL layers, each as \`{id, name, type, depth, parentId, childrenCount, width, height}\`.
 2. **Pick the layers to restore**: From the list, identify the top-level restorable layers (typically depth=0 or depth=1 FRAME/COMPONENT/INSTANCE nodes — the actual screens/cards/sections, not every nested leaf). For each, build a restorable URL: \`https://mastergo.com/file/{fileId}?layer_id={layer_id}\` (URL-encode the layer_id, e.g. \`802:02364\` → \`802%3A02364\`).
-3. **Restore ONE at a time (serial, not batch)**: Take the FIRST layer_id → run the normal single-layer restoration (Step 0 → Step 4 below: \`getDesignSections\` → fetch all sections → \`applyDesign\`) → output that layer's complete HTML. ONLY after finishing one layer's HTML, move to the NEXT layer_id and repeat. Do not start layer N+1 before layer N's HTML is done.
-4. Repeat until all picked layers are restored.
+3. **Restore ONE layer at a time, writing EACH to its OWN separate .html file**: Take the FIRST layer_id → run the normal single-layer restoration (Step 0 → Step 4 below: \`getDesignSections\` → fetch all sections → \`applyDesign\`) → write that layer's complete HTML to a SEPARATE file. ONLY after finishing one layer's HTML FILE, move to the NEXT layer_id and repeat. Do not start layer N+1 before layer N's file is fully written.
+4. Repeat until all picked layers are restored — you should end up with N separate .html files (one per layer), NOT one merged file.
 
-**CRITICAL — restore sequentially, one HTML at a time.** Do NOT fetch all layers' DSLs in parallel and merge into one HTML. Each layer is an independent restoration: finish one (including \`applyDesign\`), output it, then start the next.
+**CRITICAL — ONE LAYER = ONE STANDALONE HTML FILE. This is non-negotiable:**
+- Each layer's output is a COMPLETE, standalone HTML document with its own \`<!DOCTYPE html>\`, \`<head>\`, and \`<body>\` — NOT an HTML fragment, NOT a \`<div>\` chunk to be concatenated.
+- Do NOT combine multiple layers into one HTML file. Do NOT stack multiple layers' \`<body>\` content into a single page. Do NOT fetch all layers' DSLs in parallel and merge them.
+- Write each layer to a DISTINCT file. Name files by the layer name or layer_id (e.g. \`容器1.html\`, \`navbar.html\`, or \`layer-802-02364.html\`). If the user specified an output directory, write each file there.
+- Finish one layer completely (including \`mcp__applyDesign\` and writing the file) before starting the next.
 
 **When to use this vs. direct restoration:**
-- URL has \`page_id\` and no \`layer_id\` → ALWAYS use this workflow (a page contains many layers; restore them individually).
-- URL has a specific \`layer_id\` for a single component → use the normal workflow (Step 0+), no enumeration needed.
+- URL has \`page_id\` and no \`layer_id\` → ALWAYS use this workflow (a page contains many layers; restore them individually, each as its own file).
+- URL has a specific \`layer_id\` for a single component → use the normal workflow (Step 0+), no enumeration needed, one file.
 - A page_id returns empty (e.g. the synthetic \`page_id=M\`) → the page data isn't available via this API; ask the user for a specific layer_id URL instead.
 
 ### Step 0: Get Layout Overview (MANDATORY)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,12 @@ import packageJson from "../package.json";
 const SERVER_INSTRUCTIONS = `
 ## MasterGo Design DSL - Section-by-Section Workflow
 
+### Step -1: Page-level URL → enumerate first (when the URL has page_id)
+If the design URL contains \`page_id\` (e.g. \`?page_id=40:015\` or the default page \`?page_id=M\`) and NO specific \`layer_id\`, the URL refers to an ENTIRE PAGE, not a single component. In this case:
+1. Call \`mcp__getPageLayers\` with that page_id (passed as \`layerId\`) to enumerate ALL layers in the page.
+2. For each returned \`layer_id\`, call \`mcp__getDesignSections\` (or \`mcp__getDsl\`) to restore that layer.
+Do NOT call \`getDesignSections\` directly with a page_id as if it were a single component — a page_id enumerates many layers; restore them individually.
+
 ### Step 0: Get Layout Overview (MANDATORY)
 Call \`mcp__getDesignSections\` WITHOUT sectionIndex first.
 The response contains \`sections\` array with \`nodeCount\` per section, \`totalSections\`, and \`totalNodes\`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,21 @@ import packageJson from "../package.json";
 const SERVER_INSTRUCTIONS = `
 ## MasterGo Design DSL - Section-by-Section Workflow
 
-### Step -1: Page-level URL → enumerate first (when the URL has page_id)
-If the design URL contains \`page_id\` (e.g. \`?page_id=40:015\` or the default page \`?page_id=M\`) and NO specific \`layer_id\`, the URL refers to an ENTIRE PAGE, not a single component. In this case:
-1. Call \`mcp__getPageLayers\` with that page_id (passed as \`layerId\`) to enumerate ALL layers in the page.
-2. For each returned \`layer_id\`, call \`mcp__getDesignSections\` (or \`mcp__getDsl\`) to restore that layer.
-Do NOT call \`getDesignSections\` directly with a page_id as if it were a single component — a page_id enumerates many layers; restore them individually.
+### Step -1: Multi-layer restoration — enumerate, then restore ONE layer at a time
+Use this workflow when the user wants to restore a WHOLE PAGE or a CONTAINER with multiple child layers (e.g. URL has \`page_id\`, or a top-level frame whose children should each be restored separately). Do NOT restore all layers in one shot — restore them sequentially.
+
+**Workflow:**
+1. **Enumerate**: Call \`mcp__getPageLayers\` with the page_id / parent layerId. It returns a flat list of ALL layers, each as \`{id, name, type, depth, parentId, childrenCount, width, height}\`.
+2. **Pick the layers to restore**: From the list, identify the top-level restorable layers (typically depth=0 or depth=1 FRAME/COMPONENT/INSTANCE nodes — the actual screens/cards/sections, not every nested leaf). For each, build a restorable URL: \`https://mastergo.com/file/{fileId}?layer_id={layer_id}\` (URL-encode the layer_id, e.g. \`802:02364\` → \`802%3A02364\`).
+3. **Restore ONE at a time (serial, not batch)**: Take the FIRST layer_id → run the normal single-layer restoration (Step 0 → Step 4 below: \`getDesignSections\` → fetch all sections → \`applyDesign\`) → output that layer's complete HTML. ONLY after finishing one layer's HTML, move to the NEXT layer_id and repeat. Do not start layer N+1 before layer N's HTML is done.
+4. Repeat until all picked layers are restored.
+
+**CRITICAL — restore sequentially, one HTML at a time.** Do NOT fetch all layers' DSLs in parallel and merge into one HTML. Each layer is an independent restoration: finish one (including \`applyDesign\`), output it, then start the next.
+
+**When to use this vs. direct restoration:**
+- URL has \`page_id\` and no \`layer_id\` → ALWAYS use this workflow (a page contains many layers; restore them individually).
+- URL has a specific \`layer_id\` for a single component → use the normal workflow (Step 0+), no enumeration needed.
+- A page_id returns empty (e.g. the synthetic \`page_id=M\`) → the page data isn't available via this API; ask the user for a specific layer_id URL instead.
 
 ### Step 0: Get Layout Overview (MANDATORY)
 Call \`mcp__getDesignSections\` WITHOUT sectionIndex first.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { GetComponentWorkflowTool } from "./tools/get-component-workflow";
 import { GetFlutterWorkflowTool } from "./tools/get-flutter-workflow";
 import { GetVersionTool } from "./tools/get-version";
 import { GetDesignSectionsTool } from "./tools/get-design-sections";
+import { GetPageLayersTool } from "./tools/get-page-layers";
 import { ExtractSvgTool } from "./tools/extract-svg";
 import { ApplyDesignTool } from "./tools/apply-design";
 import { parserArgs, getEffectiveHeaders, maskSensitiveHeaders } from "./utils/args";
@@ -127,6 +128,7 @@ Each child's \`left\` and \`top\` come from that child's own \`layoutStyle.relat
 
 ### Tool Selection Rules:
 - \`mcp__getDesignSections\` is the PRIMARY tool for full-page design-to-code generation. Always start here when you need to generate a complete HTML page from a design.
+- \`mcp__getPageLayers\` ENUMERATES layer_ids. Use it when you have a page_id (layerId) and need the list of all layers inside it BEFORE restoring each layer — it returns a lightweight {id, name, type, depth, parentId, childrenCount, width, height} list, then you feed each layer_id back into \`getDesignSections\` or \`getDsl\` to restore. It CANNOT list a document's pages from a fileId alone — you must already have a page_id / layerId.
 - \`mcp__extractSvg\` is a STANDALONE tool. Use it DIRECTLY when you only need to extract SVG icons from a design — do NOT call \`getDesignSections\` before it.
 - \`mcp__getDsl\` is a FALLBACK — call it ONLY if \`getDesignSections\` returns an error (e.g. tool not available on older servers).
 - NEVER call both \`getDesignSections\` AND \`getDsl\` for the same design.
@@ -284,6 +286,7 @@ function main() {
 
   new GetVersionTool().register(server);
   new GetDesignSectionsTool().register(server);
+  new GetPageLayersTool().register(server);
   new GetDslTool().register(server);
   new GetD2cTool().register(server);
   new GetC2dTool().register(server);

--- a/src/tools/get-design-sections.ts
+++ b/src/tools/get-design-sections.ts
@@ -6,6 +6,18 @@ import { markSectionWorkflowActive, setTotalSections, trackSectionFetched } from
 
 const DESIGN_SECTIONS_TOOL_NAME = "mcp__getDesignSections";
 const DESIGN_SECTIONS_TOOL_DESCRIPTION = `
+BEFORE calling this tool, CHECK the layerId:
+- If layerId has NO colon and no digits (e.g. "M", or any short non-numeric id), it is likely a
+  PAGE-level id, NOT a layer id. Page-level ids return EMPTY from this tool (they cannot be
+  enumerated via /container).
+  → STOP. Call mcp__getPageLayers with the same fileId+layerId first to enumerate the real
+  layer_ids, then restore each one individually.
+- Only proceed with THIS tool when layerId looks like a real layer id (contains a colon and
+  digits, e.g. "802:02364", "453:6855").
+This check is MANDATORY when the user's URL contains ?page_id= (not ?layer_id=). If you ignore
+this and call this tool with a page-level id, the server will return an error redirecting you to
+mcp__getPageLayers anyway — so save the round-trip and call getPageLayers first.
+
 [PRIMARY] This is the main tool for all designs. Operates in TWO modes:
 
 Mode 1 — Get layout overview (sectionIndex NOT provided):
@@ -142,12 +154,16 @@ export class GetDesignSectionsTool extends BaseTool {
       let finalFileId = this.normalizeFileId(fileId);
       let finalLayerId = layerId;
       let finalSourceLayerId = sourceLayerId;
+      // 来源信号：仅在 shortLink 解析时由 extractIdsFromUrl 填充（layerId 来自 ?page_id= 时为 true）。
+      // LLM 直传 layerId 参数（不走 shortLink）时为 undefined——服务端软兜底不触发，由 prompt 拦截。
+      let fromPageParam: boolean | undefined;
 
       if (shortLink) {
         const ids = await httpUtilInstance.extractIdsFromUrl(shortLink);
         finalFileId = this.normalizeFileId(ids.fileId);
         finalLayerId = ids.layerId;
         finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
+        fromPageParam = ids.fromPageParam;
       }
 
       const effectiveLayerId = finalSourceLayerId || finalLayerId;
@@ -158,7 +174,8 @@ export class GetDesignSectionsTool extends BaseTool {
       const result = await httpUtilInstance.getDesignSections(
         finalFileId,
         effectiveLayerId,
-        sectionIndex
+        sectionIndex,
+        fromPageParam,
       );
 
       // 部分后端（如旧版 HTTP route）在 section list 响应里不下发 rules。

--- a/src/tools/get-page-layers.ts
+++ b/src/tools/get-page-layers.ts
@@ -15,8 +15,10 @@ layer_ids; it does NOT restore designs.
      depth 0/1). For each, build a URL: https://mastergo.com/file/{fileId}?layer_id={id}
      (URL-encode the id, e.g. 802:02364 → 802%3A02364).
   3. Restore them SEQUENTIALLY — take one layer_id, run the full single-layer restoration
-     (mcp__getDesignSections → fetch all sections → mcp__applyDesign), output its HTML,
-     THEN move to the next. Do NOT batch-restore or merge multiple layers into one HTML.
+     (mcp__getDesignSections → fetch all sections → mcp__applyDesign), write its HTML to its
+     OWN separate .html file (a complete standalone document with <!DOCTYPE html>/<head>/<body>),
+     THEN move to the next. Do NOT batch-restore. Do NOT merge multiple layers into one HTML file —
+     ONE layer = ONE standalone .html file.
 
 You can provide either:
 1. fileId and layerId directly (layerId = the page's layerId, i.e. page_id), or

--- a/src/tools/get-page-layers.ts
+++ b/src/tools/get-page-layers.ts
@@ -6,13 +6,17 @@ import { formatField, formatOutput } from "../utils/format";
 const PAGE_LAYERS_TOOL_NAME = "mcp__getPageLayers";
 const PAGE_LAYERS_TOOL_DESCRIPTION = `
 List ALL layers under a given page (or any container layer) of a MasterGo design file.
+This is the ENUMERATION step of the multi-layer restoration workflow — it only lists
+layer_ids; it does NOT restore designs.
 
-Use this when you need to enumerate the layer_ids of a page — typically BEFORE restoring
-the full design. The workflow is:
-  1. Call this tool with the page's layerId (it is the page_id from the MasterGo URL,
-     e.g. "40:015"). It returns every layer inside that page as a flat list.
-  2. For each returned layer_id, call mcp__getDesignSections or mcp__getDsl with that
-     layer_id to restore its design.
+**Workflow (enumerate → build URLs → restore one by one):**
+  1. Call this tool with the page_id / parent layerId to get the full layer list.
+  2. Pick the top-level restorable layers from the result (FRAME/COMPONENT/INSTANCE at
+     depth 0/1). For each, build a URL: https://mastergo.com/file/{fileId}?layer_id={id}
+     (URL-encode the id, e.g. 802:02364 → 802%3A02364).
+  3. Restore them SEQUENTIALLY — take one layer_id, run the full single-layer restoration
+     (mcp__getDesignSections → fetch all sections → mcp__applyDesign), output its HTML,
+     THEN move to the next. Do NOT batch-restore or merge multiple layers into one HTML.
 
 You can provide either:
 1. fileId and layerId directly (layerId = the page's layerId, i.e. page_id), or
@@ -23,7 +27,8 @@ childrenCount, width, height. It does NOT contain DSL/styles/SVG paths — use t
 or DSL tools to restore each layer.
 
 NOTE: This tool cannot enumerate a document's PAGE list from a fileId alone — you must
-already know a page_id / layerId to pass in.
+already know a page_id / layerId to pass in. The synthetic page_id=M returns empty
+(page data not available via this API); use a real layer_id URL in that case.
 `;
 
 export class GetPageLayersTool extends BaseTool {

--- a/src/tools/get-page-layers.ts
+++ b/src/tools/get-page-layers.ts
@@ -120,13 +120,19 @@ export class GetPageLayersTool extends BaseTool {
         ],
       };
     } catch (error: any) {
-      const errorMessage = error.response?.data ?? error?.message;
+      // 统一错误结构：response.data 可能是对象/字符串/undefined，归一成 { error, message } 供 LLM 稳定解析。
+      // 与 getDesignSections 的错误处理风格一致（避免 JSON.stringify 一个裸字符串得到带引号的 "..."）。
+      const errData = error?.response?.data;
+      const errorMessage =
+        (typeof errData === 'string' ? errData : errData?.message) ||
+        error?.message ||
+        'Unknown error';
       return {
         isError: true,
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(errorMessage),
+            text: JSON.stringify({ error: 'getPageLayers failed', message: errorMessage }),
           },
         ],
       };

--- a/src/tools/get-page-layers.ts
+++ b/src/tools/get-page-layers.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+import { BaseTool } from "./base-tool";
+import { httpUtilInstance } from "../utils/api";
+import { formatField, formatOutput } from "../utils/format";
+
+const PAGE_LAYERS_TOOL_NAME = "mcp__getPageLayers";
+const PAGE_LAYERS_TOOL_DESCRIPTION = `
+List ALL layers under a given page (or any container layer) of a MasterGo design file.
+
+Use this when you need to enumerate the layer_ids of a page — typically BEFORE restoring
+the full design. The workflow is:
+  1. Call this tool with the page's layerId (it is the page_id from the MasterGo URL,
+     e.g. "40:015"). It returns every layer inside that page as a flat list.
+  2. For each returned layer_id, call mcp__getDesignSections or mcp__getDsl with that
+     layer_id to restore its design.
+
+You can provide either:
+1. fileId and layerId directly (layerId = the page's layerId, i.e. page_id), or
+2. a short link (like https://{domain}/goto/LhGgBAK)
+
+The returned layer list is lightweight: each entry has id, name, type, depth, parentId,
+childrenCount, width, height. It does NOT contain DSL/styles/SVG paths — use the section
+or DSL tools to restore each layer.
+
+NOTE: This tool cannot enumerate a document's PAGE list from a fileId alone — you must
+already know a page_id / layerId to pass in.
+`;
+
+export class GetPageLayersTool extends BaseTool {
+  name = PAGE_LAYERS_TOOL_NAME;
+  description = PAGE_LAYERS_TOOL_DESCRIPTION;
+
+  constructor() {
+    super();
+  }
+
+  schema = z.object({
+    fileId: z
+      .string()
+      .optional()
+      .describe(
+        "MasterGo design file ID (format: file/<fileId> in MasterGo URL). Required if shortLink is not provided."
+      ),
+    layerId: z
+      .string()
+      .optional()
+      .describe(
+        "Page layer ID to enumerate. This is the page_id from the MasterGo URL (e.g. \"40:015\"). Required if shortLink is not provided."
+      ),
+    sourceLayerId: z
+      .string()
+      .optional()
+      .describe(
+        "Source layer ID from URL parameter source_layer_id. When provided, use this instead of layerId for all queries."
+      ),
+    shortLink: z
+      .string()
+      .optional()
+      .describe("Short link (like https://{domain}/goto/LhGgBAK)."),
+    format: formatField(),
+  }).passthrough();
+
+  async execute({ fileId, layerId, shortLink, sourceLayerId, format, ...rest }: z.infer<typeof this.schema>) {
+    try {
+      // 阻断未知参数（与 getDesignSections 一致）：排除 _ 前缀元字段。
+      const unknownKeys = Object.keys(rest as Record<string, unknown>).filter((k) => !k.startsWith("_"));
+      if (unknownKeys.length > 0) {
+        const errorText = `Unknown parameter(s): ${unknownKeys.join(", ")}. This tool only accepts: fileId, layerId, sourceLayerId, shortLink, format. Remove the unknown parameter(s) and retry.`;
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: errorText }),
+            },
+          ],
+        };
+      }
+
+      if (!shortLink && (!fileId || (!layerId && !sourceLayerId))) {
+        throw new Error(
+          "Either provide fileId with layerId (or sourceLayerId), or provide a shortLink"
+        );
+      }
+
+      let finalFileId = this.normalizeFileId(fileId);
+      let finalLayerId = layerId;
+      let finalSourceLayerId = sourceLayerId;
+
+      if (shortLink) {
+        const ids = await httpUtilInstance.extractIdsFromUrl(shortLink);
+        finalFileId = this.normalizeFileId(ids.fileId);
+        finalLayerId = ids.layerId;
+        finalSourceLayerId = ids.sourceLayerId ?? sourceLayerId;
+      }
+
+      const effectiveLayerId = finalSourceLayerId || finalLayerId;
+      if (!finalFileId || !effectiveLayerId) {
+        throw new Error("Could not determine fileId or layerId (need layerId or sourceLayerId)");
+      }
+
+      const result = await httpUtilInstance.getPageLayers(
+        finalFileId,
+        effectiveLayerId
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: formatOutput(result, format),
+          },
+        ],
+      };
+    } catch (error: any) {
+      const errorMessage = error.response?.data ?? error?.message;
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(errorMessage),
+          },
+        ],
+      };
+    }
+  }
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -193,9 +193,9 @@ export const isSameHost = (a: string, b: string): boolean => {
 // shortLink → 解析结果 LRU 缓存：避免 section 工作流里同一短链重复 redirect。
 // stdio 长驻进程，缓存条目极少（一次会话只涉及少数设计稿），设 32 条上限防无限增长。
 const SHORT_LINK_CACHE_MAX = 32;
-const shortLinkCache = new Map<string, { fileId: string; layerId: string; sourceLayerId?: string }>();
+const shortLinkCache = new Map<string, { fileId: string; layerId: string; sourceLayerId?: string; fromPageParam?: boolean }>();
 /** LRU 写入：已有 key 先 delete 再 set 移到末尾；超容量淘汰最久未访问的 key。 */
-function cacheShortLink(key: string, value: { fileId: string; layerId: string; sourceLayerId?: string }): void {
+function cacheShortLink(key: string, value: { fileId: string; layerId: string; sourceLayerId?: string; fromPageParam?: boolean }): void {
   if (shortLinkCache.has(key)) shortLinkCache.delete(key);
   else if (shortLinkCache.size >= SHORT_LINK_CACHE_MAX) {
     const oldest = shortLinkCache.keys().next().value;
@@ -425,11 +425,13 @@ const createHttpUtil = () => {
       return response.data;
     },
 
-    async getDesignSections(fileId: string, layerId: string, sectionIndex?: number): Promise<DesignSectionsResponse> {
+    async getDesignSections(fileId: string, layerId: string, sectionIndex?: number, fromPageParam?: boolean): Promise<DesignSectionsResponse> {
       const key = dslCacheKey('sections', fileId, layerId, sectionIndex !== undefined ? String(sectionIndex) : 'list');
       return withDslCache(key, async () => {
         const params: Record<string, any> = { fileId, layerId };
         if (sectionIndex !== undefined) params.sectionIndex = sectionIndex;
+        // 仅当确认为 pageId 来源时下发，服务端软兜底据此区分「pageId 误入」vs「真空设计」。
+        if (fromPageParam) params.fromPageParam = 'true';
 
         try {
           const response = await axios.get(`${getBaseUrl()}/mcp/design-sections`, {
@@ -566,7 +568,7 @@ const createHttpUtil = () => {
      */
     async extractIdsFromUrl(
       url: string
-    ): Promise<{ fileId: string; layerId: string; sourceLayerId?: string }> {
+    ): Promise<{ fileId: string; layerId: string; sourceLayerId?: string; fromPageParam?: boolean }> {
       // shortLink 缓存命中：直接返回，跳过 redirect
       if (url.includes("/goto/") && shortLinkCache.has(url)) {
         return { ...shortLinkCache.get(url)! };
@@ -605,15 +607,22 @@ const createHttpUtil = () => {
 
       // layer_id 优先；缺失时回退到 page_id（两者在后端都是同一套 layerId 语义，
       // page_id 是 MasterGo URL 的页面级标识，如 ?page_id=40:015 或默认页 ?page_id=M）。
+      // 保留来源信号 fromPageParam：只有 layer_id 缺失、靠 page_id 兜底时才 true。
+      // 服务端用它做软兜底——确认是 pageId 误入（而非真空设计）时返回 pageId 引导。
       const fileId = pathSegments.find((segment) => /^\d+$/.test(segment));
-      const layerId = searchParams.get("layer_id") ?? searchParams.get("page_id");
+      const layerIdFromLayer = searchParams.get("layer_id");
+      const layerIdFromPage = searchParams.get("page_id");
+      const layerId = layerIdFromLayer ?? layerIdFromPage;
+      // 仅当 layer_id 缺失、由 page_id 提供时才标记。LLM 直传 layerId 参数（不走本函数）
+      // 时 fromPageParam 为 undefined，服务端软兜底不触发——这是有意设计，避免启发式误判。
+      const fromPageParam = !layerIdFromLayer && !!layerIdFromPage;
 
       if (!fileId) throw new Error("Could not extract fileId from URL");
       if (!layerId) throw new Error("Could not extract layerId from URL");
 
       const sourceLayerId = searchParams.get("source_layer_id") || undefined;
 
-      const result = { fileId, layerId, sourceLayerId };
+      const result = { fileId, layerId, sourceLayerId, fromPageParam };
       // shortLink 解析结果写入缓存（非 shortLink 不写：纯本地解析无网络开销）
       if (url.includes("/goto/")) {
         cacheShortLink(url, result);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -603,9 +603,10 @@ const createHttpUtil = () => {
       const pathSegments = urlObj.pathname.split("/");
       const searchParams = new URLSearchParams(urlObj.search);
 
-      // Extract fileId and layerId
+      // layer_id 优先；缺失时回退到 page_id（两者在后端都是同一套 layerId 语义，
+      // page_id 是 MasterGo URL 的页面级标识，如 ?page_id=40:015 或默认页 ?page_id=M）。
       const fileId = pathSegments.find((segment) => /^\d+$/.test(segment));
-      const layerId = searchParams.get("layer_id");
+      const layerId = searchParams.get("layer_id") ?? searchParams.get("page_id");
 
       if (!fileId) throw new Error("Could not extract fileId from URL");
       if (!layerId) throw new Error("Could not extract layerId from URL");

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -67,6 +67,29 @@ export interface DesignSectionsResponse {
   [k: string]: any;
 }
 
+/** getPageLayers 响应：某 page 下的全部图层级摘要列表 */
+export interface PageLayersResponse {
+  fileId: string;
+  pageLayerId: string;
+  pageName?: string;
+  pageType?: string;
+  totalLayers: number;
+  layers: Array<{
+    id: string;
+    name: string;
+    type: string;
+    depth: number;
+    parentId?: string;
+    childrenCount: number;
+    width?: number;
+    height?: number;
+  }>;
+  /** 超过 MAX_LAYERS 上限时为 true，layers 被截断 */
+  partial?: boolean;
+  message?: string;
+  [k: string]: any;
+}
+
 /** extractSvg 响应(分页) */
 export interface ExtractSvgResponse {
   totalCount: number;
@@ -425,6 +448,32 @@ const createHttpUtil = () => {
           throw err;
         }
       });
+    },
+
+    /**
+     * 枚举某 page（layerId）下的全部图层 id 列表。
+     *
+     * 不复用 withDslCache：本接口返回的是轻量图层级摘要（id/name/type/depth/parentId），
+     * 与 section DSL 缓存语义不同；且调用方通常拿到列表后会紧接着逐个调 getDesignSections
+     * （那些请求自带 dslCache），无需在此再缓存一层。
+     */
+    async getPageLayers(fileId: string, layerId: string): Promise<PageLayersResponse> {
+      try {
+        const response = await axios.get(`${getBaseUrl()}/mcp/page-layers`, {
+          timeout: 120000,
+          params: { fileId, layerId },
+          headers: getCommonHeader(),
+        });
+        return response.data;
+      } catch (err: any) {
+        if (err.response?.status === 404) {
+          throw new Error(
+            `page-layers API not available on this server. ` +
+            `Please update frontend-mcp-server to the latest version.`
+          );
+        }
+        throw err;
+      }
     },
 
     async getD2c(contentId: string,documentId: string): Promise<DslResponse> {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -204,6 +204,33 @@ function cacheShortLink(key: string, value: { fileId: string; layerId: string; s
   shortLinkCache.set(key, value);
 }
 
+// getPageLayers 枚举结果缓存：LLM 拿到列表后常会「枚举→逐个还原」多次调用同一 page，
+// 超大 page 重复拉取数万条 layer 摘要开销显著。枚举结果是只读快照，缓存安全（不会脏读）。
+// 短 TTL（60s）：兼顾「避免重复拉」与「画布上报后能较快看到新数据」。
+const PAGE_LAYERS_CACHE_TTL_MS = 60000;
+const PAGE_LAYERS_CACHE_MAX = 32;
+const pageLayersCache = new Map<string, { data: PageLayersResponse; ts: number }>();
+function getCachedPageLayers(key: string): PageLayersResponse | undefined {
+  const entry = pageLayersCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.ts >= PAGE_LAYERS_CACHE_TTL_MS) {
+    pageLayersCache.delete(key);
+    return undefined;
+  }
+  // LRU：命中后移到末尾。
+  pageLayersCache.delete(key);
+  pageLayersCache.set(key, entry);
+  return entry.data;
+}
+function setCachedPageLayers(key: string, data: PageLayersResponse): void {
+  if (pageLayersCache.has(key)) pageLayersCache.delete(key);
+  else if (pageLayersCache.size >= PAGE_LAYERS_CACHE_MAX) {
+    const oldest = pageLayersCache.keys().next().value;
+    if (oldest !== undefined) pageLayersCache.delete(oldest);
+  }
+  pageLayersCache.set(key, { data, ts: Date.now() });
+}
+
 /**
  * DSL 响应缓存 + in-flight 请求去重。
  *
@@ -455,17 +482,21 @@ const createHttpUtil = () => {
     /**
      * 枚举某 page（layerId）下的全部图层 id 列表。
      *
-     * 不复用 withDslCache：本接口返回的是轻量图层级摘要（id/name/type/depth/parentId），
-     * 与 section DSL 缓存语义不同；且调用方通常拿到列表后会紧接着逐个调 getDesignSections
-     * （那些请求自带 dslCache），无需在此再缓存一层。
+     * 带 60s TTL 内存缓存：LLM 在「枚举→逐个还原」工作流中常多次调用同一 page，
+     * 超大 page 重复拉取开销显著。枚举结果是只读快照，缓存安全；后续 getDesignSections
+     * 逐个还原时自带 dslCache，不与此缓存冲突。失败结果不缓存（避免缓存错误态）。
      */
     async getPageLayers(fileId: string, layerId: string): Promise<PageLayersResponse> {
+      const cacheKey = `${fileId}:${layerId}`;
+      const cached = getCachedPageLayers(cacheKey);
+      if (cached) return cached;
       try {
         const response = await axios.get(`${getBaseUrl()}/mcp/page-layers`, {
           timeout: 120000,
           params: { fileId, layerId },
           headers: getCommonHeader(),
         });
+        setCachedPageLayers(cacheKey, response.data);
         return response.data;
       } catch (err: any) {
         if (err.response?.status === 404) {


### PR DESCRIPTION
## 背景

配套 frontend-mcp-server 的 `GET /mcp/page-layers` REST 路由。客户端是**硬编码 tool 目录**（非动态代理 Server tool 列表），新增 tool 需在客户端同步：tool 类 + axios 方法 + 注册，否则 LLM 看不到也调不到。

## 改动

| 文件 | 改动 |
|---|---|
| `src/tools/get-page-layers.ts` | 新增 tool 类 `GetPageLayersTool` |
| `src/utils/api.ts` | 新增 `httpUtilInstance.getPageLayers` 方法 + `PageLayersResponse` 类型，打 Server 的 `/mcp/page-layers` |
| `src/index.ts` | 注册 tool，并同步 `SERVER_INSTRUCTIONS` 的 Tool Selection Rules |

## 能力

`mcp__getPageLayers(fileId, layerId)` — layerId 即 page_id，返回该 page 下全部图层的轻量摘要列表 `{id, name, type, depth, parentId, childrenCount, width, height}`。调用方拿到 layer_id 列表后，再逐个用 `getDesignSections`/`getDsl` 还原设计。

## ⚠️ 发布铁律

**必须先上线 frontend-mcp-server（含 `/mcp/page-layers` 路由），再发布本客户端到 NPM**，否则升级后的客户端调用会 404。

## 验证

- `tsc --noEmit` exit=0 零输出