### PR TITLE
feat: 支持 --no-prefix / MG_NO_PREFIX 无前缀工具名注册（兼容 Grok Build）

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Restore design, save as HTML file: https://{domain}/goto/{shortLink}
 ### Command Line Options
 
 ```
-npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header "Key: Value"] [--debug] [--no-rule]
+npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header "Key: Value"] [--debug] [--no-rule] [--no-prefix]
 ```
 
 #### Parameters:
@@ -86,6 +86,7 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 - `--format=FORMAT` (optional): Default output format for design-data tools — one of `json` (default), `yaml`, `tree`. An explicit per-call `format` tool parameter overrides this. Also settable via the `DEFAULT_FORMAT` environment variable.
 - `--debug` (optional): Enable debug mode for detailed error information
 - `--no-rule` (optional): Disable default rules
+- `--no-prefix` (optional): Register tools without the `mcp__` name prefix (e.g. `getDsl` instead of `mcp__getDsl`). Some MCP clients (such as Grok Build) silently skip tools whose fully-qualified `server__tool` name contains more than one `__` separator — since the server is already prefixed, a `mcp__getDsl` tool name becomes `server__mcp__getDsl` and is dropped. Enable this flag for those clients. Also settable via the `MG_NO_PREFIX` environment variable (`1`/`true`/`yes`).
 
 You can also use space-separated format for parameters:
 
@@ -101,6 +102,7 @@ Alternatively, you can use environment variables instead of command line argumen
 - `API_BASE_URL`: API base URL
 - `RULES`: JSON array of rules (e.g., `'["rule1", "rule2"]'`)
 - `DEFAULT_FORMAT`: Default output format for design-data tools (`json` | `yaml` | `tree`); the `--format` argument and an explicit per-call `format` tool parameter take precedence.
+- `MG_NO_PREFIX`: Set to `1`/`true`/`yes` to register tools without the `mcp__` name prefix (the `--no-prefix` argument takes priority).
 - `HTTPS_PROXY` / `https_proxy` / `HTTP_PROXY` / `http_proxy`: HTTP(S) proxy URL (the `--proxy` argument takes priority)
 
 ### Tool Output Format

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ MCP 服务连接成功后，可以在 AI 对话中使用以下提示词：
 ### 命令行选项
 
 ```
-npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header "Key: Value"] [--debug] [--no-rule]
+npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [--proxy=PROXY_URL] [--format=FORMAT] [--header "Key: Value"] [--debug] [--no-rule] [--no-prefix]
 ```
 
 #### 参数:
@@ -86,6 +86,7 @@ npx @mastergo/magic-mcp --token=YOUR_TOKEN [--url=API_URL] [--rule=RULE_NAME] [-
 - `--format=FORMAT` (可选): 设计数据工具的默认输出格式 —— 取值 `json`（默认）、`yaml`、`tree`。工具调用时显式传入的 `format` 参数优先级更高。也可通过 `DEFAULT_FORMAT` 环境变量设置。
 - `--debug` (可选): 启用调试模式，提供详细错误信息
 - `--no-rule` (可选): 禁用默认规则
+- `--no-prefix` (可选): 工具注册时不带 `mcp__` 名称前缀（如 `getDsl` 而非 `mcp__getDsl`）。部分 MCP 客户端（如 Grok Build）会静默跳过全限定名 `server__tool` 中含多个 `__` 分隔符的工具——服务端名已带前缀时，`mcp__getDsl` 会变成 `server__mcp__getDsl` 而被丢弃。为这类客户端启用此开关即可。也可通过 `MG_NO_PREFIX` 环境变量设置（`1`/`true`/`yes`）。
 
 你也可以使用空格分隔的参数格式:
 
@@ -101,6 +102,7 @@ npx @mastergo/magic-mcp --token YOUR_TOKEN --url API_URL --rule RULE_NAME --prox
 - `API_BASE_URL`: API 基础 URL
 - `RULES`: 规则的 JSON 数组 (例如: `'["rule1", "rule2"]'`)
 - `DEFAULT_FORMAT`: 设计数据工具的默认输出格式（`json` | `yaml` | `tree`）；`--format` 参数和工具调用时显式传入的 `format` 参数优先级更高。
+- `MG_NO_PREFIX`: 设为 `1`/`true`/`yes` 时工具注册不带 `mcp__` 名称前缀（`--no-prefix` 参数优先级更高）。
 - `HTTPS_PROXY` / `https_proxy` / `HTTP_PROXY` / `http_proxy`: HTTP(S) 代理地址（`--proxy` 参数优先级更高）
 
 ### 工具输出格式

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:watch": "node build.js --watch",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "test": "esbuild test/format.test.ts test/headers.test.ts test/url-safety.test.ts test/cache-invalidate.test.ts --bundle --platform=node --format=cjs --outdir=.test --out-extension:.js=.cjs && node --test .test/format.test.cjs .test/headers.test.cjs .test/url-safety.test.cjs .test/cache-invalidate.test.cjs",
+    "test": "esbuild test/format.test.ts test/headers.test.ts test/url-safety.test.ts test/cache-invalidate.test.ts test/tool-prefix.test.ts --bundle --platform=node --format=cjs --outdir=.test --out-extension:.js=.cjs && node --test .test/format.test.cjs .test/headers.test.cjs .test/url-safety.test.cjs .test/cache-invalidate.test.cjs .test/tool-prefix.test.cjs",
     "start": "node dist/index.js --token=test --url=http://localhost:3000 --debug",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { ExtractSvgTool } from "./tools/extract-svg";
 import { ApplyDesignTool } from "./tools/apply-design";
 import { parserArgs, getEffectiveHeaders, maskSensitiveHeaders } from "./utils/args";
 import { normalizeFormat } from "./utils/format";
+import { setNoPrefix, applyToolPrefix, getNoPrefix } from "./utils/tool-prefix";
 import packageJson from "../package.json";
 
 const SERVER_INSTRUCTIONS = `
@@ -243,7 +244,11 @@ If any item above is unchecked, your HTML is INCOMPLETE. Fix it before outputtin
 
 function main() {
   // Parse command line arguments and set environment variables
-  const { token, baseUrl, rules, debug, noRule, proxy, format } = parserArgs();
+  const { token, baseUrl, rules, debug, noRule, noPrefix, proxy, format } = parserArgs();
+
+  // `--no-prefix` / MG_NO_PREFIX: 注册无 `mcp__` 前缀的工具名（兼容 Grok Build 等客户端）。
+  // 必须在任何工具注册 / 指令生成之前调用，保证工具名与指令文本一致。
+  setNoPrefix(noPrefix);
 
   // `--format` (json|yaml|tree) sets the default output format for design-data tools.
   // An explicit per-call `format` tool parameter still takes precedence (see utils/format.ts).
@@ -267,6 +272,7 @@ function main() {
     console.log(`API URL: ${baseUrl || "default"}`);
     console.log(`Rules: ${rules.length > 0 ? rules.join(", ") : "none"}`);
     console.log(`No Rule: ${noRule ? "enabled" : "disabled"}`);
+    console.log(`No Prefix: ${getNoPrefix() ? "enabled (tools registered without 'mcp__' prefix)" : "disabled (default: 'mcp__' prefix)"}`);
     console.log(`Proxy: ${proxy || "none"}`);
     const effectiveHeaders = getEffectiveHeaders();
     console.log(`Custom Headers: ${Object.keys(effectiveHeaders).length > 0 ? JSON.stringify(maskSensitiveHeaders(effectiveHeaders)) : "none"}`);
@@ -279,7 +285,7 @@ function main() {
       name: "MasterGoMcpServer",
       version: packageJson.version,
     },
-    { instructions: SERVER_INSTRUCTIONS }
+    { instructions: applyToolPrefix(SERVER_INSTRUCTIONS) }
   );
 
   new GetVersionTool().register(server);

--- a/src/tools/apply-design.ts
+++ b/src/tools/apply-design.ts
@@ -5,8 +5,8 @@ import { clearSectionWorkflow } from "./get-dsl";
 import { writeFile, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
+import { toolName } from "../utils/tool-prefix";
 
-const APPLY_DESIGN_TOOL_NAME = "mcp__applyDesign";
 const APPLY_DESIGN_TOOL_DESCRIPTION = `
 Finalize generated design code: replace ALL placeholders (SVG icons + long text) with real high-precision data from the design cache, then write the final file directly to disk.
 
@@ -37,7 +37,9 @@ IMPORTANT: Call this tool with the COMPLETE code string. After the tool writes t
 `;
 
 export class ApplyDesignTool extends BaseTool {
-  name = APPLY_DESIGN_TOOL_NAME;
+  get name() {
+    return toolName("applyDesign");
+  }
   description = APPLY_DESIGN_TOOL_DESCRIPTION;
 
   constructor() {

--- a/src/tools/base-tool.ts
+++ b/src/tools/base-tool.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { applyToolPrefix } from "../utils/tool-prefix";
 
 export abstract class BaseTool {
   abstract name: string;
@@ -9,7 +10,9 @@ export abstract class BaseTool {
   register(server: McpServer) {
     server.tool(
       this.name,
-      this.description,
+      // 描述文本里引用的是带 `mcp__` 前缀的工具名，需随当前前缀设置同步改写，
+      // 否则无前缀模式下模型会被引导去调用不存在的 `mcp__xxx` 工具。
+      applyToolPrefix(this.description),
       this.schema.shape,
       this.execute.bind(this)
     );

--- a/src/tools/extract-svg.ts
+++ b/src/tools/extract-svg.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import { formatField, formatOutput } from "../utils/format";
+import { toolName } from "../utils/tool-prefix";
 
-const EXTRACT_SVG_TOOL_NAME = "mcp__extractSvg";
 const EXTRACT_SVG_TOOL_DESCRIPTION = `
 Extract SVG data from MasterGo design files. This tool retrieves the DSL from a design layer, finds all PATH nodes (typically inside INSTANCE/icon components), resolves their color references, and generates SVG markup strings.
 You can provide either:
@@ -14,7 +14,9 @@ Pagination: When there are many icons, use the first call without "page" to get 
 `;
 
 export class ExtractSvgTool extends BaseTool {
-  name = EXTRACT_SVG_TOOL_NAME;
+  get name() {
+    return toolName("extractSvg");
+  }
   description = EXTRACT_SVG_TOOL_DESCRIPTION;
 
   constructor() {

--- a/src/tools/get-c2d.ts
+++ b/src/tools/get-c2d.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import fs from "fs";
+import { toolName } from "../utils/tool-prefix";
 
 /** 读取文件大小上限：10MB，防止 LLM 传入超大 HTML 文件阻塞事件循环。 */
 const C2D_MAX_FILE_SIZE = 10 * 1024 * 1024;
 
-const C2D_TOOL_NAME = "mcp__C2d";
 const C2D_TOOL_DESCRIPTION = `
 使用此工具将代码文件发送到 MasterGo MCP 服务进行 C2D（代码转设计）处理，将用户代码同步到设计稿。
 
@@ -22,7 +22,9 @@ const C2D_TOOL_DESCRIPTION = `
 `;
 
 export class GetC2dTool extends BaseTool {
-  name = C2D_TOOL_NAME;
+  get name() {
+    return toolName("C2d");
+  }
   description = C2D_TOOL_DESCRIPTION;
 
   constructor() {

--- a/src/tools/get-component-link.ts
+++ b/src/tools/get-component-link.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { toolName } from "../utils/tool-prefix";
 
-const COMPONENT_LINK_TOOL_NAME = "mcp__getComponentLink";
 const COMPONENT_LINK_TOOL_DESCRIPTION = `When the data returned by mcp__getDsl contains a non-empty componentDocumentLinks array, this tool is used to sequentially retrieve URLs from the componentDocumentLinks array and then obtain component documentation data. The returned document data is used for you to generate frontend code based on components.`;
 
 export class GetComponentLinkTool extends BaseTool {
-  name = COMPONENT_LINK_TOOL_NAME;
+  get name() {
+    return toolName("getComponentLink");
+  }
   description = COMPONENT_LINK_TOOL_DESCRIPTION;
 
   constructor() {

--- a/src/tools/get-component-workflow.ts
+++ b/src/tools/get-component-workflow.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import fs from "fs";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { toolName } from "../utils/tool-prefix";
 import componentWorkflow from "../markdown/component-workflow.md";
 
 /**
@@ -46,7 +47,6 @@ function createConcurrencyLimiter(maxConcurrency: number) {
 const WRITE_FILE_CONCURRENCY = 32;
 const CHILDREN_RECURSION_CONCURRENCY = 8;
 
-const COMPONENT_GENERATOR_TOOL_NAME = "mcp__getComponentGenerator";
 const COMPONENT_GENERATOR_TOOL_DESCRIPTION = `
 Users need to actively call this tool to get the component development workflow. When Generator is mentioned, please actively call this tool.
 This tool provides a structured workflow for component development following best practices.
@@ -54,7 +54,9 @@ You must provide an absolute rootPath of workspace to save workflow files.
 `;
 
 export class GetComponentWorkflowTool extends BaseTool {
-  name = COMPONENT_GENERATOR_TOOL_NAME;
+  get name() {
+    return toolName("getComponentGenerator");
+  }
   description = COMPONENT_GENERATOR_TOOL_DESCRIPTION;
 
   constructor() {

--- a/src/tools/get-d2c.ts
+++ b/src/tools/get-d2c.ts
@@ -5,8 +5,8 @@ import axios from "axios";
 import path from "path";
 import { existsSync, mkdirSync } from "fs";
 import { writeFile } from "fs/promises";
+import { toolName } from "../utils/tool-prefix";
 
-const D2C_TOOL_NAME = "mcp__getD2c";
 const D2C_TOOL_DESCRIPTION = `
 使用此工具从 MasterGo 获取 D2C 数据，并在本地落盘：
 1）将返回的 code 写入 html；
@@ -270,7 +270,9 @@ function extractPayload(d2c: any): {
 }
 
 export class GetD2cTool extends BaseTool {
-  name = D2C_TOOL_NAME;
+  get name() {
+    return toolName("getD2c");
+  }
   description = D2C_TOOL_DESCRIPTION;
 
   constructor() {

--- a/src/tools/get-design-sections.ts
+++ b/src/tools/get-design-sections.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import { formatField, formatOutput } from "../utils/format";
+import { toolName, applyToolPrefix } from "../utils/tool-prefix";
 import { markSectionWorkflowActive, setTotalSections, trackSectionFetched } from "./get-dsl";
 
-const DESIGN_SECTIONS_TOOL_NAME = "mcp__getDesignSections";
 const DESIGN_SECTIONS_TOOL_DESCRIPTION = `
 [PRIMARY] This is the main tool for all designs. Operates in TWO modes:
 
@@ -72,7 +72,9 @@ const DSL_RULES: string[] = [
 
 
 export class GetDesignSectionsTool extends BaseTool {
-  name = DESIGN_SECTIONS_TOOL_NAME;
+  get name() {
+    return toolName("getDesignSections");
+  }
   description = DESIGN_SECTIONS_TOOL_DESCRIPTION;
 
   constructor() {
@@ -170,7 +172,7 @@ export class GetDesignSectionsTool extends BaseTool {
         typeof result === "object" &&
         (!result.rules || !Array.isArray(result.rules) || result.rules.length === 0)
       ) {
-        result.rules = DSL_RULES;
+        result.rules = DSL_RULES.map((r) => applyToolPrefix(r));
       }
 
       // section list 模式：在响应里注入 nextAction 显式指令，防止 LLM 跳过 section DSL 拉取。
@@ -192,7 +194,7 @@ export class GetDesignSectionsTool extends BaseTool {
           const maxSibling = Math.max(...highSiblingSections.map((s: any) => s.structureSiblingCount));
           siblingWarning = ` WARNING: ${highSiblingSections.length} sections have structureSiblingCount up to ${maxSibling} — they look identical in the list (same nodeCount, empty name) but each has DIFFERENT text content and variant state. You MUST fetch ALL of them individually (do NOT skip any after fetching a few). Skipping sibling sections causes missing active-state styling and wrong menu item rendering.`;
         }
-        result.nextAction = `STOP. This section LIST is only a directory — it has NO DSL nodes,  NO rowTexts. You CANNOT generate HTML from this list alone. Your NEXT ACTION: call mcp__getDesignSections with sectionIndex=0, then sectionIndex=1, ... up to sectionIndex=${n - 1} (total ${n} calls). Fetch ALL ${n} sections in batches of 3-5 before writing ANY HTML. Sections with nodeCount=3 and empty name are NOT empty — they contain real menu items and content (resolved from INSTANCE overrides during DSL transfer).${siblingWarning} Skipping section DSL fetch is the #1 cause of missing menus, broken icons, and wrong data.`;
+        result.nextAction = applyToolPrefix(`STOP. This section LIST is only a directory — it has NO DSL nodes,  NO rowTexts. You CANNOT generate HTML from this list alone. Your NEXT ACTION: call mcp__getDesignSections with sectionIndex=0, then sectionIndex=1, ... up to sectionIndex=${n - 1} (total ${n} calls). Fetch ALL ${n} sections in batches of 3-5 before writing ANY HTML. Sections with nodeCount=3 and empty name are NOT empty — they contain real menu items and content (resolved from INSTANCE overrides during DSL transfer).${siblingWarning} Skipping section DSL fetch is the #1 cause of missing menus, broken icons, and wrong data.`);
         // 检测多列布局：动态计算主内容区位置
         const scList = result.splitContainers;
         if (Array.isArray(scList) && scList.length > 0) {

--- a/src/tools/get-dsl.ts
+++ b/src/tools/get-dsl.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import { formatField, formatOutput } from "../utils/format";
+import { toolName, applyToolPrefix } from "../utils/tool-prefix";
 
 // 进程级跟踪：记录已通过 getDesignSections 拉取过 section list 的 fileId+layerId。
 // 如果 LLM 在 section 工作流进行中调 getDsl，会返回 195KB+ 的全量数据撑爆上下文窗口，
@@ -95,7 +96,6 @@ export function clearSectionWorkflow(fileId: string, layerId: string): void {
   trackerTimestamps.delete(key);
 }
 
-const DSL_TOOL_NAME = "mcp__getDsl";
 const DSL_TOOL_DESCRIPTION = `
 [FALLBACK] Use only when mcp__getDesignSections is unavailable or returns an error.
 This returns the FULL DSL in one response — may be large and exceed context limits for complex designs.
@@ -109,7 +109,9 @@ The DSL data can also be used to transform and generate code for different frame
 `;
 
 export class GetDslTool extends BaseTool {
-  name = DSL_TOOL_NAME;
+  get name() {
+    return toolName("getDsl");
+  }
   description = DSL_TOOL_DESCRIPTION;
 
   constructor() {
@@ -177,7 +179,7 @@ export class GetDslTool extends BaseTool {
             {
               type: "text" as const,
               text: JSON.stringify({
-                error: "getDsl BLOCKED: You have already started the section workflow (mcp__getDesignSections) for this design. Do NOT call getDsl during or after the section workflow — it returns 195KB+ of full DSL data that will exhaust your context window and prevent you from fetching remaining sections. Continue fetching section DSL via mcp__getDesignSections with sectionIndex=N. If you need data you think only getDsl provides, it is already available in the section DSL responses (rowTexts, dsl.nodes).",
+                error: applyToolPrefix("getDsl BLOCKED: You have already started the section workflow (mcp__getDesignSections) for this design. Do NOT call getDsl during or after the section workflow — it returns 195KB+ of full DSL data that will exhaust your context window and prevent you from fetching remaining sections. Continue fetching section DSL via mcp__getDesignSections with sectionIndex=N. If you need data you think only getDsl provides, it is already available in the section DSL responses (rowTexts, dsl.nodes)."),
               }),
             },
           ],

--- a/src/tools/get-flutter-workflow.ts
+++ b/src/tools/get-flutter-workflow.ts
@@ -6,9 +6,9 @@ import axios from "axios";
 import https from "https";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
+import { toolName, applyToolPrefix } from "../utils/tool-prefix";
 import flutterComponentWorkflow from "../markdown/flutter-component-workflow.md";
 
-const FLUTTER_GENERATOR_TOOL_NAME = "mcp__getFlutterGenerator";
 const FLUTTER_GENERATOR_TOOL_DESCRIPTION = `
 Users need to actively call this tool to get the Flutter component development workflow. When Flutter Generator or Flutter Component is mentioned, please actively call this tool.
 This tool provides a structured workflow for Flutter component development following best practices.
@@ -641,7 +641,9 @@ function rewriteDslUrls(node: any, urlMap: Map<string, string>): void {
 // ---------------------------------------------------------------------------
 
 export class GetFlutterWorkflowTool extends BaseTool {
-  name = FLUTTER_GENERATOR_TOOL_NAME;
+  get name() {
+    return toolName("getFlutterGenerator");
+  }
   description = FLUTTER_GENERATOR_TOOL_DESCRIPTION;
 
   constructor() {
@@ -975,13 +977,13 @@ export class GetFlutterWorkflowTool extends BaseTool {
     const assetRulePath = assetDirRelative;
     const lostMsg =
       unresolvedLostImageRefs.length > 0
-        ? `WARNING: ${unresolvedLostImageRefs.length} image references were LOST by the MasterGo upstream (cssCode contains url([object Object])). These cannot be recovered from the style API. Affected node IDs: ${Array.from(
+        ? applyToolPrefix(`WARNING: ${unresolvedLostImageRefs.length} image references were LOST by the MasterGo upstream (cssCode contains url([object Object])). These cannot be recovered from the style API. Affected node IDs: ${Array.from(
             new Set(unresolvedLostImageRefs.map((l) => l.nodeId))
           )
             .slice(0, 20)
             .join(", ")}${
             unresolvedLostImageRefs.length > 20 ? " …" : ""
-          }. Use placeholder widgets (Container with grey background + Icon) or ask the user to re-export via mcp__getD2c for those nodes.`
+          }. Use placeholder widgets (Container with grey background + Icon) or ask the user to re-export via mcp__getD2c for those nodes.`)
         : null;
 
     return {

--- a/src/tools/get-meta.ts
+++ b/src/tools/get-meta.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 import { BaseTool } from "./base-tool";
 import { httpUtilInstance } from "../utils/api";
 import { formatField, formatOutput } from "../utils/format";
+import { toolName, applyToolPrefix } from "../utils/tool-prefix";
 import rules from "../markdown/meta.md";
 
-const META_TOOL_NAME = "mcp__getMeta";
 const META_TOOL_DESCRIPTION = `
 Use this tool when the user intends to build a complete website or needs to obtain high-level site
 configuration information. You must provide a fileld and layerld to identify the specific design element.
@@ -13,7 +13,9 @@ follow the rules and use the results to analyze the site and page.
 `;
 
 export class GetMetaTool extends BaseTool {
-  name = META_TOOL_NAME;
+  get name() {
+    return toolName("getMeta");
+  }
   description = META_TOOL_DESCRIPTION;
 
   constructor() {
@@ -47,7 +49,8 @@ export class GetMetaTool extends BaseTool {
         content: [
           {
             type: "text" as const,
-            text: formatOutput({ result, rules }, format),
+            // meta.md 里引用的工具名带 `mcp__` 前缀，需随当前前缀设置同步改写。
+            text: formatOutput({ result, rules: applyToolPrefix(rules) }, format),
           },
         ],
       };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { parseToken, parseUrl, parseRules, parseNoRule, parseProxy, getEffectiveHeaders } from "./args";
+import { applyToolPrefix } from "./tool-prefix";
 import https from "https";
 import { HttpsProxyAgent } from "https-proxy-agent";
 
@@ -317,7 +318,7 @@ const extractComponentDocumentLinks = (dsl: DslResponse): string[] => {
 };
 
 const buildDslRules = (): string[] => {
-  return [
+  const rules = [
     "CRITICAL — Page positioning: the section LIST response contains splitContainers with page-absolute coordinates for each page region. Use splitContainers to construct the page skeleton (position:absolute with exact coordinates). Do NOT guess or stack with flex.",
     "CRITICAL — Sidebar columns: render ALL sidebar levels as persistent columns at splitContainers positions. Do NOT hide or toggle them.",
     "token filed must be generated as a variable (colors, shadows, fonts, etc.) and the token field must be displayed in the comment",
@@ -339,6 +340,8 @@ const buildDslRules = (): string[] => {
     ...(JSON.parse(process.env.RULES ?? "[]") as string[]),
     ...parseRules(),
   ];
+  // 规则文本里的工具名带 `mcp__` 前缀，需随当前前缀设置同步改写。
+  return rules.map((r) => applyToolPrefix(r));
 };
 
 /**

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -75,6 +75,18 @@ function parseNoRule(): boolean {
   return false;
 }
 
+function parseNoPrefix(): boolean {
+  const args = getArgs();
+
+  for (const arg of args) {
+    if (arg === "--no-prefix") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function parseProxy(): string {
   const args = getArgs();
   let proxy = "";
@@ -280,6 +292,7 @@ export function parserArgs(): {
   rules: string[];
   debug: boolean;
   noRule: boolean;
+  noPrefix: boolean;
   proxy: string;
   format: string | undefined;
 } {
@@ -288,6 +301,7 @@ export function parserArgs(): {
   const rules = parseRules();
   const debug = parseDebug();
   const noRule = parseNoRule();
+  const noPrefix = parseNoPrefix();
   const proxy = parseProxy();
   const format = parseFormat();
 
@@ -297,9 +311,10 @@ export function parserArgs(): {
     rules,
     debug,
     noRule,
+    noPrefix,
     proxy,
     format,
   };
 }
 
-export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseProxy, parseFormat, parseHeaders, parseEnvHeaders, getEffectiveHeaders, maskSensitiveHeaders, getArgs };
+export { parseToken, parseUrl, parseRules, parseDebug, parseNoRule, parseNoPrefix, parseProxy, parseFormat, parseHeaders, parseEnvHeaders, getEffectiveHeaders, maskSensitiveHeaders, getArgs };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -75,7 +75,7 @@ function parseNoRule(): boolean {
   return false;
 }
 
-function parseNoPrefix(): boolean {
+function parseNoPrefix(): boolean | undefined {
   const args = getArgs();
 
   for (const arg of args) {
@@ -84,7 +84,8 @@ function parseNoPrefix(): boolean {
     }
   }
 
-  return false;
+  // 未显式传 `--no-prefix`：返回 undefined，交由 MG_NO_PREFIX 环境变量决定。
+  return undefined;
 }
 
 function parseProxy(): string {
@@ -292,7 +293,7 @@ export function parserArgs(): {
   rules: string[];
   debug: boolean;
   noRule: boolean;
-  noPrefix: boolean;
+  noPrefix: boolean | undefined;
   proxy: string;
   format: string | undefined;
 } {

--- a/src/utils/tool-prefix.ts
+++ b/src/utils/tool-prefix.ts
@@ -13,7 +13,7 @@
 let _noPrefix: boolean | null = null;
 
 function parseEnvNoPrefix(): boolean {
-  const v = process.env.MG_NO_PREFIX;
+  const v = (process.env.MG_NO_PREFIX ?? "").toLowerCase();
   return v === "1" || v === "true" || v === "yes";
 }
 
@@ -23,11 +23,15 @@ function resolveNoPrefix(): boolean {
   return _noPrefix;
 }
 
-/** 解析出 `--no-prefix` 后调用，覆盖环境变量。 */
-export function setNoPrefix(v: boolean): void {
-  _noPrefix = v;
-  // 同步 env，保证运行时其它模块（如 api.ts 的 buildDslRules）读取一致。
-  process.env.MG_NO_PREFIX = v ? "1" : "0";
+/**
+ * 显式设置是否启用无前缀模式。
+ * `undefined` 表示调用方未显式指定（未传 `--no-prefix`），保持从环境变量读取；
+ * 传 `true`/`false` 时覆盖环境变量（CLI 参数优先于 `MG_NO_PREFIX`）。
+ */
+export function setNoPrefix(v: boolean | undefined): void {
+  if (v !== undefined) {
+    _noPrefix = v;
+  }
 }
 
 /** 重置缓存的解析结果，回到从环境变量读取。测试用。 */

--- a/src/utils/tool-prefix.ts
+++ b/src/utils/tool-prefix.ts
@@ -1,0 +1,60 @@
+/**
+ * 工具名前缀工具。
+ *
+ * 默认所有工具名为 `mcp__xxx` 形式（如 `mcp__getDesignSections`）。部分 MCP 客户端
+ * （如 Grok Build）要求工具全限定名 `server__tool` 中恰好只有一个 `__` 分隔符——工具名
+ * 自身再含 `__`（如 `mcp__getDsl`）会被静默跳过注册（见 issue #115）。
+ *
+ * 提供 `--no-prefix` 命令行参数 / `MG_NO_PREFIX` 环境变量，开启后：
+ *   - 工具名不带 `mcp__` 前缀（`getDsl`、`getDesignSections` …）；
+ *   - 所有指令/描述文本中的 `mcp__` 引用同步改写，避免模型调用不存在的工具名。
+ */
+
+let _noPrefix: boolean | null = null;
+
+function parseEnvNoPrefix(): boolean {
+  const v = process.env.MG_NO_PREFIX;
+  return v === "1" || v === "true" || v === "yes";
+}
+
+function resolveNoPrefix(): boolean {
+  if (_noPrefix !== null) return _noPrefix;
+  _noPrefix = parseEnvNoPrefix();
+  return _noPrefix;
+}
+
+/** 解析出 `--no-prefix` 后调用，覆盖环境变量。 */
+export function setNoPrefix(v: boolean): void {
+  _noPrefix = v;
+  // 同步 env，保证运行时其它模块（如 api.ts 的 buildDslRules）读取一致。
+  process.env.MG_NO_PREFIX = v ? "1" : "0";
+}
+
+/** 重置缓存的解析结果，回到从环境变量读取。测试用。 */
+export function resetNoPrefix(): void {
+  _noPrefix = null;
+}
+
+/** 当前是否启用无前缀模式。 */
+export function getNoPrefix(): boolean {
+  return resolveNoPrefix();
+}
+
+/** 当前工具名前缀：无前缀模式下为空串，否则为 `mcp__`。 */
+export function getToolPrefix(): string {
+  return getNoPrefix() ? "" : "mcp__";
+}
+
+/** 生成工具名：`getToolPrefix() + base`，例如 base="getDsl" → "mcp__getDsl" 或 "getDsl"。 */
+export function toolName(base: string): string {
+  return `${getToolPrefix()}${base}`;
+}
+
+/**
+ * 把一段含 `mcp__` 工具名引用的文本改写成当前前缀下的正确引用。
+ * 无前缀模式下 `mcp__getDsl` → `getDsl`；默认模式下原样返回。
+ */
+export function applyToolPrefix(text: string): string {
+  const prefix = getToolPrefix();
+  return prefix === "mcp__" ? text : text.replace(/mcp__/g, prefix);
+}

--- a/test/tool-prefix.test.ts
+++ b/test/tool-prefix.test.ts
@@ -146,6 +146,21 @@ test("env: MG_NO_PREFIX=0 / unset keeps default prefix", () => {
   assert.equal(getNoPrefix(), false);
 });
 
+test("env: MG_NO_PREFIX values are case-insensitive", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "TRUE";
+  assert.equal(getNoPrefix(), true);
+  reset();
+  process.env.MG_NO_PREFIX = "True";
+  assert.equal(getNoPrefix(), true);
+  reset();
+  process.env.MG_NO_PREFIX = "YES";
+  assert.equal(getNoPrefix(), true);
+  reset();
+  process.env.MG_NO_PREFIX = "No";
+  assert.equal(getNoPrefix(), false);
+});
+
 // ---- parseNoPrefix() from args ----
 
 test("parseNoPrefix: --no-prefix flag returns true", () => {
@@ -157,10 +172,10 @@ test("parseNoPrefix: --no-prefix flag returns true", () => {
   }
 });
 
-test("parseNoPrefix: absent flag returns false", () => {
+test("parseNoPrefix: absent flag returns undefined (defer to env)", () => {
   try {
     withArgv("--debug", "--token", "x");
-    assert.equal(parseNoPrefix(), false);
+    assert.equal(parseNoPrefix(), undefined);
   } finally {
     restoreArgv();
   }
@@ -178,8 +193,60 @@ test("parseNoPrefix: --no-prefix mixed with other flags", () => {
 test("parseNoPrefix: --no-prefix=false form is ignored (only exact flag counts)", () => {
   try {
     withArgv("--no-prefix=false");
-    assert.equal(parseNoPrefix(), false);
+    assert.equal(parseNoPrefix(), undefined);
   } finally {
     restoreArgv();
   }
+});
+
+// ---- integration path: main() sets setNoPrefix(parseNoPrefix()) ----
+
+test("integration: MG_NO_PREFIX=1 + no --no-prefix keeps env-driven no-prefix", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "1";
+  try {
+    withArgv("--token", "test"); // 无 --no-prefix → parseNoPrefix() 返回 undefined
+    const noPrefix = parseNoPrefix();
+    assert.equal(noPrefix, undefined);
+    setNoPrefix(noPrefix); // main() 中无条件调用，但 undefined 不应覆盖 env
+    assert.equal(getNoPrefix(), true);
+    assert.equal(toolName("getDsl"), "getDsl");
+    assert.equal(toolName("getDesignSections"), "getDesignSections");
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("integration: MG_NO_PREFIX unset + no --no-prefix keeps default prefix", () => {
+  reset();
+  try {
+    withArgv("--token", "test");
+    setNoPrefix(parseNoPrefix());
+    assert.equal(getNoPrefix(), false);
+    assert.equal(toolName("getDsl"), "mcp__getDsl");
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("integration: --no-prefix overrides MG_NO_PREFIX=0", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "0";
+  try {
+    withArgv("--no-prefix");
+    setNoPrefix(parseNoPrefix());
+    assert.equal(getNoPrefix(), true);
+    assert.equal(toolName("getDsl"), "getDsl");
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("setNoPrefix: does not mutate process.env.MG_NO_PREFIX", () => {
+  reset();
+  delete process.env.MG_NO_PREFIX;
+  setNoPrefix(true);
+  assert.equal(process.env.MG_NO_PREFIX, undefined);
+  setNoPrefix(false);
+  assert.equal(process.env.MG_NO_PREFIX, undefined);
 });

--- a/test/tool-prefix.test.ts
+++ b/test/tool-prefix.test.ts
@@ -1,0 +1,185 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  toolName,
+  getToolPrefix,
+  getNoPrefix,
+  applyToolPrefix,
+  setNoPrefix,
+  resetNoPrefix,
+} from "../src/utils/tool-prefix";
+import { parseNoPrefix } from "../src/utils/args";
+
+// ---- helpers ----
+
+// Reset the cached no-prefix result AND the env var so each test starts clean.
+const reset = () => {
+  resetNoPrefix();
+  delete process.env.MG_NO_PREFIX;
+};
+
+// parseNoPrefix() reads process.argv.slice(2), so drive it by setting argv.
+const ORIG_ARGV = process.argv;
+const withArgv = (...args: string[]) => {
+  process.argv = ["node", "mastergo-magic-mcp", ...args];
+};
+const restoreArgv = () => {
+  process.argv = ORIG_ARGV;
+};
+
+// ---- defaults (env unset) ----
+
+test("default: toolName keeps mcp__ prefix", () => {
+  reset();
+  assert.equal(toolName("getDsl"), "mcp__getDsl");
+  assert.equal(toolName("getDesignSections"), "mcp__getDesignSections");
+});
+
+test("default: getToolPrefix() === 'mcp__' and getNoPrefix() === false", () => {
+  reset();
+  assert.equal(getToolPrefix(), "mcp__");
+  assert.equal(getNoPrefix(), false);
+});
+
+test("default: applyToolPrefix leaves text unchanged", () => {
+  reset();
+  const text = "call mcp__getDesignSections then mcp__applyDesign";
+  assert.equal(applyToolPrefix(text), text);
+});
+
+// ---- setNoPrefix(true): tools register without mcp__ ----
+
+test("no-prefix: toolName drops mcp__ prefix", () => {
+  reset();
+  setNoPrefix(true);
+  assert.equal(toolName("getDsl"), "getDsl");
+  assert.equal(toolName("getDesignSections"), "getDesignSections");
+});
+
+test("no-prefix: getToolPrefix() === '' and getNoPrefix() === true", () => {
+  reset();
+  setNoPrefix(true);
+  assert.equal(getToolPrefix(), "");
+  assert.equal(getNoPrefix(), true);
+});
+
+test("no-prefix: applyToolPrefix rewrites mcp__ references", () => {
+  reset();
+  setNoPrefix(true);
+  assert.equal(
+    applyToolPrefix("call mcp__getDesignSections then mcp__applyDesign"),
+    "call getDesignSections then applyDesign"
+  );
+});
+
+test("no-prefix: applyToolPrefix rewrites a multi-line rules block", () => {
+  reset();
+  setNoPrefix(true);
+  const rules = [
+    "Use mcp__getDsl to fetch DSL.",
+    "Then call mcp__applyDesign as the final step.",
+    "Do not call mcp__getDsl twice.",
+  ];
+  assert.deepEqual(applyToolPrefix(rules.join("\n")).split("\n"), [
+    "Use getDsl to fetch DSL.",
+    "Then call applyDesign as the final step.",
+    "Do not call getDsl twice.",
+  ]);
+});
+
+// ---- setNoPrefix(false): explicit disable ----
+
+test("no-prefix=false: toolName keeps mcp__ prefix even when env says no-prefix", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "1";
+  setNoPrefix(false);
+  assert.equal(toolName("getDsl"), "mcp__getDsl");
+  assert.equal(applyToolPrefix("mcp__getDsl"), "mcp__getDsl");
+});
+
+// ---- resetNoPrefix(): back to env-based reading ----
+
+test("resetNoPrefix: after reset, env var controls the result", () => {
+  reset();
+  setNoPrefix(true);
+  assert.equal(toolName("getDsl"), "getDsl");
+
+  // Delete env to simulate a fresh process with no MG_NO_PREFIX: reset should
+  // restore the default prefixed names even though setNoPrefix(true) ran earlier.
+  resetNoPrefix();
+  delete process.env.MG_NO_PREFIX;
+  assert.equal(toolName("getDsl"), "mcp__getDsl");
+});
+
+test("resetNoPrefix: re-reads MG_NO_PREFIX after setNoPrefix override", () => {
+  reset();
+  setNoPrefix(true);
+  process.env.MG_NO_PREFIX = "0";
+  resetNoPrefix();
+  assert.equal(getNoPrefix(), false);
+  assert.equal(toolName("getDsl"), "mcp__getDsl");
+});
+
+// ---- env var MG_NO_PREFIX ----
+
+test("env: MG_NO_PREFIX=1 enables no-prefix mode", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "1";
+  assert.equal(getNoPrefix(), true);
+  assert.equal(getToolPrefix(), "");
+  assert.equal(toolName("applyDesign"), "applyDesign");
+});
+
+test("env: MG_NO_PREFIX=true/yes also enable no-prefix mode", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "true";
+  assert.equal(getNoPrefix(), true);
+  process.env.MG_NO_PREFIX = "yes";
+  assert.equal(getNoPrefix(), true);
+});
+
+test("env: MG_NO_PREFIX=0 / unset keeps default prefix", () => {
+  reset();
+  process.env.MG_NO_PREFIX = "0";
+  assert.equal(getNoPrefix(), false);
+  delete process.env.MG_NO_PREFIX;
+  assert.equal(getNoPrefix(), false);
+});
+
+// ---- parseNoPrefix() from args ----
+
+test("parseNoPrefix: --no-prefix flag returns true", () => {
+  try {
+    withArgv("--no-prefix");
+    assert.equal(parseNoPrefix(), true);
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseNoPrefix: absent flag returns false", () => {
+  try {
+    withArgv("--debug", "--token", "x");
+    assert.equal(parseNoPrefix(), false);
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseNoPrefix: --no-prefix mixed with other flags", () => {
+  try {
+    withArgv("--token", "test", "--no-prefix", "--debug");
+    assert.equal(parseNoPrefix(), true);
+  } finally {
+    restoreArgv();
+  }
+});
+
+test("parseNoPrefix: --no-prefix=false form is ignored (only exact flag counts)", () => {
+  try {
+    withArgv("--no-prefix=false");
+    assert.equal(parseNoPrefix(), false);
+  } finally {
+    restoreArgv();
+  }
+});


### PR DESCRIPTION
## 背景

GitHub issue #115：Grok Build 等 MCP 客户端要求工具全限定名 `server__tool` **恰好只含一个 `__` 分隔符**。服务端名已带 `server` 前缀时，`mcp__getDsl` 会变成 `server__mcp__getDsl`，含两个 `__`，导致工具被客户端**静默跳过**。报告中只有不带前缀的 `version_0_2_6` 工具能被 Grok 注册，与根因吻合。

## 方案

新增 **`--no-prefix` 命令行参数 / `MG_NO_PREFIX` 环境变量**，非破坏性、按需开启：

- 开启后所有工具注册为**无 `mcp__` 前缀**的名称（`getDsl`、`getDesignSections` …），`server__getDsl` 只有一个 `__`，可被 Grok Build 正常注册；
- 所有内嵌 `mcp__` 工具名引用的文本同步改写，避免模型被引导调用不存在的 `mcp__xxx`：
  - `SERVER_INSTRUCTIONS`（index.ts）
  - 全部工具描述（BaseTool.register）
  - `DSL_RULES` / `nextAction`（get-design-sections.ts）
  - `buildDslRules`（api.ts）
  - `meta.md`（get-meta.ts）
  - 动态运行时串：`getDsl BLOCKED`、flutter `lostMsg`

## 实现

- 新增 `src/utils/tool-prefix.ts`：`toolName()` / `getToolPrefix()` / `applyToolPrefix()` / `setNoPrefix()` / `resetNoPrefix()`
- 所有工具 `name` 改为 `get name()` 统一走 `toolName()`
- `args.ts` 新增 `parseNoPrefix()`，`index.ts` 在注册前调用 `setNoPrefix()`
- 新增 `test/tool-prefix.test.ts`（默认/无前缀/环境变量/CLI 各分支）

## 验证

- `yarn test`：72 个测试全部通过（含新增 15 个）
- `yarn lint`：0 error（仅存量 69 个 `no-explicit-any` warning）
- `yarn build`：成功
- 运行时冒烟测试（stdio JSON-RPC `tools/list`）：
  - 默认模式：`mcp__getDesignSections`、`mcp__getDsl` 等 10 个带前缀 + 1 个 `version_0_2_6`（本就无前缀）
  - `--no-prefix` 模式：11 个工具全部无前缀，`getDesignSections`、`getDsl` 均正常注册

Closes #115