### PR TITLE
fix(release): 修复 npm 发布配置

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,12 +35,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
@@ -98,7 +98,13 @@ jobs:
           done
 
       - name: Publish to NPM
-        run: npm publish
+        run: |
+          NPM_TAG=latest
+          case "${{ github.event.inputs.release-type }}" in
+            beta) NPM_TAG=beta ;;
+            alpha) NPM_TAG=alpha ;;
+          esac
+          npm publish --access public --tag "$NPM_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "author": "",
   "license": "ISC",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "axios": "1.18.1",


### PR DESCRIPTION
## 变更内容

- 配置 npm 包为 public 发布
- beta/alpha 版本使用对应 dist-tag
- 升级 checkout 和 setup-node action 到 v5
- 使用新的 NPM_TOKEN Secret 发布 @mastergo/magic-mcp

## 验证

- npm test：85/85 通过
- git diff --check 通过